### PR TITLE
Fixed num_connections error when invalid values are given

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -165,6 +165,12 @@ int main( int argc, char *argv[] )
 	if( j > -1 )
 		conf->verbose = j;
 
+	if ( conf->num_connections < 1)
+	{
+		print_help();
+		return( 1 );
+	}
+
 	if( argc - optind == 0 )
 	{
 		print_help();


### PR DESCRIPTION
For custom number of connections, if the value given is less than 1, the program halts with Segmentation Fault. Added a check in `src/text.c` which checks `conf->num_connections` to be greater than 1 after the parameters have been passed, otherwise it executes `print_help()` and terminates. 