### PR TITLE
Add missing m4 path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_PREREQ([2.69])
 AC_INIT([axel], [2.6], [https://github.com/eribertomota/axel/issues])
 AC_CONFIG_SRCDIR([src/conf.h])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE
 
 # Checks for programs.


### PR DESCRIPTION
Fixes these errors when running ./autogen.sh on Linux

    Copying file config.rpath
    Copying file /codeset.m4
    cp: cannot create regular file ‘/codeset.m4’: Permission denied
    Copying file /fcntl-o.m4
    cp: cannot create regular file ‘/fcntl-o.m4’: Permission denied
    Copying file /gettext.m4
    cp: cannot create regular file ‘/gettext.m4’: Permission denied
    Copying file /glibc2.m4
    (... lots more of these)