### PR TITLE
https & ftps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ after ./autogen.sh, is running ./configure, make and make install.
 
 Install the following homebrew packages:
 
-  `homebrew install automake gettext`
+  `homebrew install automake gettext openssl`
 
 You'll need to provide some extra options to `autogen.sh` and `configure`
-so they can find gettext.
+so they can find gettext and openssl.
 
 ```shell
 GETTEXT=/usr/local/opt/gettext
+OPENSSL=/usr/local/opt/openssl
 PATH="$GETTEXT/bin:$PATH"
 ./autogen.sh -I$GETTEXT/share/aclocal/
-CFLAGS=-I$GETTEXT/include LDFLAGS=-L$GETTEXT/lib ./configure
+CFLAGS="-I$GETTEXT/include -I$OPENSSL/include" LDFLAGS=-L$GETTEXT/lib ./configure
 ```
+
+You can just run `make` as usual after these steps.

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,12 @@ AC_TYPE_SIZE_T
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([gettimeofday inet_ntoa memset select setlocale socket strcasecmp strchr strrchr strstr])
+AC_SEARCH_LIBS([SSL_library_init], [ssl], [], [
+    AC_MSG_ERROR([libssl not found])
+])
+AC_SEARCH_LIBS([ERR_get_error], [crypto], [], [
+    AC_MSG_ERROR([libcrypto not found])
+])
 
 # Add Gettext
 AM_GNU_GETTEXT([external])
@@ -44,22 +50,22 @@ CFLAGS="$CFLAGS -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall"
 
 case "$arch" in
 FreeBSD | OpenBSD | NetBSD | Darwin )
-    LDFLAGS="$LDFLAGS -lintl -lssl -lcrypto -pthread"
+    LDFLAGS="$LDFLAGS -lintl -pthread"
 ;;
 Linux | GNU/kFreeBSD | GNU )
-    LDFLAGS="$LDFLAGS -lssl -lcrypto -pthread"
+    LDFLAGS="$LDFLAGS -pthread"
 ;;
 SunOS )
-    LDFLAGS="$LDFLAGS -lintl -lssl -lcrypto -pthread -lsocket -lnsl"
+    LDFLAGS="$LDFLAGS -lintl -pthread -lsocket -lnsl"
 ;;
 HP-UX )
     if [ -d /usr/local/lib/hpux32 ]; then
        AXEL_EXTRA_FLAGS="-L/usr/local/lib/hpux32"
     fi
-    LDFLAGS="$LDFLAGS $AXEL_EXTRA_FLAGS -lintl -lssl -lcrypto -lpthread"
+    LDFLAGS="$LDFLAGS $AXEL_EXTRA_FLAGS -lintl -lpthread"
 ;;
 * )
-    LDFLAGS="$LDFLAGS -lintl -lssl -lcrypto -pthread"
+    LDFLAGS="$LDFLAGS -lintl -pthread"
 ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,22 +44,22 @@ CFLAGS="$CFLAGS -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall"
 
 case "$arch" in
 FreeBSD | OpenBSD | NetBSD | Darwin )
-    LDFLAGS="$LDFLAGS -lintl -pthread"
+    LDFLAGS="$LDFLAGS -lintl -lssl -lcrypto -pthread"
 ;;
 Linux | GNU/kFreeBSD | GNU )
-    LDFLAGS="$LDFLAGS -pthread"
+    LDFLAGS="$LDFLAGS -lssl -lcrypto -pthread"
 ;;
 SunOS )
-    LDFLAGS="$LDFLAGS -lintl -pthread -lsocket -lnsl"
+    LDFLAGS="$LDFLAGS -lintl -lssl -lcrypto -pthread -lsocket -lnsl"
 ;;
 HP-UX )
     if [ -d /usr/local/lib/hpux32 ]; then
        AXEL_EXTRA_FLAGS="-L/usr/local/lib/hpux32"
     fi
-    LDFLAGS="$LDFLAGS $AXEL_EXTRA_FLAGS -lintl -lpthread"
+    LDFLAGS="$LDFLAGS $AXEL_EXTRA_FLAGS -lintl -lssl -lcrypto -lpthread"
 ;;
 * )
-    LDFLAGS="$LDFLAGS -lintl -pthread"
+    LDFLAGS="$LDFLAGS -lintl -lssl -lcrypto -pthread"
 ;;
 esac
 

--- a/man/axel.1
+++ b/man/axel.1
@@ -57,6 +57,11 @@ Do not use any proxy server to download the file. Not possible when a transparen
 is active somewhere, of course.
 .TP
 .B
+\fB--insecure\fP, \fB-k\fP
+Don't verify the SSL certificate. Only use this if you are getting certificate
+errors and you are sure of the sites authenticity.
+.TP
+.B
 \fB--verbose\fP, \fB-v\fP
 Show more status messages. Use it more than once to see more details.
 .TP

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,3 +4,4 @@ src/conn.c
 src/ftp.c
 src/http.c
 src/text.c
+src/ssl.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,3 +5,4 @@ src/ftp.c
 src/http.c
 src/text.c
 src/ssl.c
+src/tcp.c

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-30 22:57-0300\n"
+"POT-Creation-Date: 2016-03-31 17:29+1100\n"
 "PO-Revision-Date: 2008-09-15 22:08+0200\n"
 "Last-Translator: Hermann J. Beckers <hj.beckers@onlinehome.de>\n"
 "Language-Team: deutsch <de@li.org>\n"
@@ -56,85 +56,85 @@ msgstr "Fehler beim Öffnen der lokalen Datei"
 msgid "Starting download"
 msgstr "Starte Abruf"
 
-#: src/axel.c:253 src/axel.c:412
+#: src/axel.c:253 src/axel.c:413
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Verbindung %i: Abruf von %s:%i über Schnittstelle %s"
 
-#: src/axel.c:260 src/axel.c:422
+#: src/axel.c:260 src/axel.c:423
 msgid "pthread error!!!"
 msgstr "pthread Fehler!!!"
 
-#: src/axel.c:328
+#: src/axel.c:329
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Fehler bei Verbindung %i! Verbindung getrennt"
 
-#: src/axel.c:342
+#: src/axel.c:343
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Verbindung %i unerwartet getrennt"
 
-#: src/axel.c:346 src/axel.c:363
+#: src/axel.c:347 src/axel.c:364
 #, c-format
 msgid "Connection %i finished"
 msgstr "Verbindung %i beendet"
 
-#: src/axel.c:375
+#: src/axel.c:376
 msgid "Write error!"
 msgstr "Schreibfehler!"
 
-#: src/axel.c:387
+#: src/axel.c:388
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Time-out bei Verbindung %i"
 
-#: src/conf.c:107
+#: src/conf.c:108
 #, c-format
 msgid "Error in %s line %i.\n"
 msgstr "Fehler in %s Zeile %i.\n"
 
-#: src/conn.c:349 src/ftp.c:122
+#: src/conn.c:344 src/ftp.c:119
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Zu viele Weiterleitungen (redirects).\n"
 
-#: src/conn.c:368
+#: src/conn.c:363
 #, c-format
 msgid "Unknown HTTP error.\n"
 msgstr "Unbekannter HTTP-Fehler.\n"
 
-#: src/ftp.c:33 src/http.c:61
+#: src/ftp.c:33 src/http.c:62
 #, c-format
 msgid "Unable to connect to server %s:%i\n"
 msgstr "Keine Verbindung mit %s:%i möglich\n"
 
-#: src/ftp.c:89
+#: src/ftp.c:86
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "Kann nicht in Verzeichnis %s wechseln\n"
 
-#: src/ftp.c:115 src/ftp.c:175
+#: src/ftp.c:112 src/ftp.c:171
 #, c-format
 msgid "File not found.\n"
 msgstr "Datei nicht gefunden.\n"
 
-#: src/ftp.c:177
+#: src/ftp.c:173
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Mehrere Treffer für diese URL.\n"
 
-#: src/ftp.c:248 src/ftp.c:254
+#: src/ftp.c:244 src/ftp.c:250
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Fehler beim Öffnen der Passiv-Verbindung.\n"
 
-#: src/ftp.c:284
+#: src/ftp.c:280
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Fehler beim Schreiben des Befehls %s\n"
 
-#: src/ftp.c:309 src/http.c:161
+#: src/ftp.c:305 src/http.c:172
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Verbindung geschlossen.\n"
@@ -144,67 +144,67 @@ msgstr "Verbindung geschlossen.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "Ungültige Proxy-Angabe: %s\n"
 
-#: src/http.c:147
+#: src/http.c:158
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Verbindung geschlossen.\n"
 
-#: src/text.c:156
+#: src/text.c:160
 #, c-format
 msgid "Can't redirect stdout to /dev/null.\n"
 msgstr "Kann Standardausgabe nicht nach /dev/null umleiten.\n"
 
-#: src/text.c:184
+#: src/text.c:189
 #, c-format
 msgid "Error when trying to read URL (Too long?).\n"
 msgstr "Fehler beim Lesen der URL (Zu lang?).\n"
 
-#: src/text.c:193
+#: src/text.c:198
 #, c-format
 msgid "Can't handle URLs of length over %d\n"
 msgstr "Kann URLs mit mehr als %d Zeichen nicht nutzen\n"
 
-#: src/text.c:198
+#: src/text.c:203
 #, c-format
 msgid "Initializing download: %s\n"
 msgstr "Starte Abruf: %s\n"
 
-#: src/text.c:205
+#: src/text.c:210
 #, c-format
 msgid "Doing search...\n"
 msgstr "Suche gestartet...\n"
 
-#: src/text.c:209
+#: src/text.c:214
 #, c-format
 msgid "File not found\n"
 msgstr "Datei nicht gefunden\n"
 
-#: src/text.c:213
+#: src/text.c:218
 #, c-format
 msgid "Testing speeds, this can take a while...\n"
 msgstr "Teste Geschwindigkeiten, das kann etwas dauern...\n"
 
-#: src/text.c:218
+#: src/text.c:223
 #, c-format
 msgid "%i usable servers found, will use these URLs:\n"
 msgstr "%i benutzbare Server gefunden, werde diese URLs benutzen:\n"
 
-#: src/text.c:277
+#: src/text.c:282
 #, c-format
 msgid "Filename too long!\n"
 msgstr "Dateiname zu lang!\n"
 
-#: src/text.c:289
+#: src/text.c:294
 #, c-format
 msgid "No state file, cannot resume!\n"
 msgstr "Keine Status-Datei, Fortsetzung nicht möglich!\n"
 
-#: src/text.c:294
+#: src/text.c:299
 #, c-format
 msgid "State file found, but no downloaded data. Starting from scratch.\n"
 msgstr "Status-Datei gefunden, aber noch nichts übertragen. Neustart.\n"
 
-#: src/text.c:425
+#: src/text.c:430
 #, c-format
 msgid ""
 "\n"
@@ -213,47 +213,47 @@ msgstr ""
 "\n"
 "%s abgerufen in %s. (%.2f KB/s)\n"
 
-#: src/text.c:447
+#: src/text.c:452
 #, c-format
 msgid "%lld byte"
 msgstr "%lld byte"
 
-#: src/text.c:449
+#: src/text.c:454
 #, c-format
 msgid "%.1f Kilobyte"
 msgstr "%.1f Kilobytes"
 
-#: src/text.c:451
+#: src/text.c:456
 #, c-format
 msgid "%.1f Megabyte"
 msgstr "%.1f Megabytes"
 
-#: src/text.c:453
+#: src/text.c:458
 #, c-format
 msgid "%.1f Gigabyte"
 msgstr "%.1f Gigabytes"
 
-#: src/text.c:462
+#: src/text.c:467
 #, c-format
 msgid "%i second"
 msgstr "%i Sekunde"
 
-#: src/text.c:464
+#: src/text.c:469
 #, c-format
 msgid "%i seconds"
 msgstr "%i Sekunden"
 
-#: src/text.c:466
+#: src/text.c:471
 #, fuzzy, c-format
 msgid "%i:%02i minute(s)"
 msgstr "%i:%02i Sekunden"
 
-#: src/text.c:468
+#: src/text.c:473
 #, fuzzy, c-format
 msgid "%i:%02i:%02i hour(s)"
 msgstr "%i:%02i:%02i Sekunden"
 
-#: src/text.c:557
+#: src/text.c:562
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -265,6 +265,7 @@ msgid ""
 "-H x\tAdd header string\n"
 "-U x\tSet user agent\n"
 "-N\tJust don't use any proxy server\n"
+"-k\tDon't verify the SSL certificate\n"
 "-q\tLeave stdout alone\n"
 "-v\tMore status information\n"
 "-a\tAlternate progress indicator\n"
@@ -289,8 +290,8 @@ msgstr ""
 "\n"
 "Fehler an lintux@lintux.cx melden.\n"
 
-#: src/text.c:574
-#, c-format
+#: src/text.c:580
+#, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
 "\n"
@@ -301,6 +302,7 @@ msgid ""
 "--header=x\t\t-H x\tAdd header string\n"
 "--user-agent=x\t\t-U x\tSet user agent\n"
 "--no-proxy\t\t-N\tJust don't use any proxy server\n"
+"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 "--quiet\t\t\t-q\tLeave stdout alone\n"
 "--verbose\t\t-v\tMore status information\n"
 "--alternate\t\t-a\tAlternate progress indicator\n"
@@ -325,24 +327,29 @@ msgstr ""
 "\n"
 "Fehler an lintux@lintux.cx melden.\n"
 
-#: src/text.c:595
+#: src/text.c:602
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Axel version %s (%s)\n"
 msgstr "Axel Version %s (%s)\n"
 
-#: src/text.c:598
+#: src/text.c:605
 #, c-format
 msgid ""
 "\n"
 "                    and others."
 msgstr ""
 
-#: src/text.c:599
+#: src/text.c:606
 #, c-format
 msgid ""
 "\n"
 "Please, see the CREDITS file.\n"
 "\n"
+msgstr ""
+
+#: src/ssl.c:65
+#, c-format
+msgid "SSL connection failed: %s\n"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-31 17:29+1100\n"
+"POT-Creation-Date: 2016-03-31 21:56+1100\n"
 "PO-Revision-Date: 2008-09-15 22:08+0200\n"
 "Last-Translator: Hermann J. Beckers <hj.beckers@onlinehome.de>\n"
 "Language-Team: deutsch <de@li.org>\n"
@@ -94,7 +94,7 @@ msgstr "Time-out bei Verbindung %i"
 msgid "Error in %s line %i.\n"
 msgstr "Fehler in %s Zeile %i.\n"
 
-#: src/conn.c:344 src/ftp.c:119
+#: src/conn.c:344 src/ftp.c:117
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Zu viele Weiterleitungen (redirects).\n"
@@ -104,37 +104,32 @@ msgstr "Zu viele Weiterleitungen (redirects).\n"
 msgid "Unknown HTTP error.\n"
 msgstr "Unbekannter HTTP-Fehler.\n"
 
-#: src/ftp.c:33 src/http.c:62
-#, c-format
-msgid "Unable to connect to server %s:%i\n"
-msgstr "Keine Verbindung mit %s:%i möglich\n"
-
-#: src/ftp.c:86
+#: src/ftp.c:84
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "Kann nicht in Verzeichnis %s wechseln\n"
 
-#: src/ftp.c:112 src/ftp.c:171
+#: src/ftp.c:110 src/ftp.c:169
 #, c-format
 msgid "File not found.\n"
 msgstr "Datei nicht gefunden.\n"
 
-#: src/ftp.c:173
+#: src/ftp.c:171
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Mehrere Treffer für diese URL.\n"
 
-#: src/ftp.c:244 src/ftp.c:250
+#: src/ftp.c:242
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Fehler beim Öffnen der Passiv-Verbindung.\n"
 
-#: src/ftp.c:280
+#: src/ftp.c:275
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Fehler beim Schreiben des Befehls %s\n"
 
-#: src/ftp.c:305 src/http.c:172
+#: src/ftp.c:300 src/http.c:169
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Verbindung geschlossen.\n"
@@ -144,7 +139,7 @@ msgstr "Verbindung geschlossen.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "Ungültige Proxy-Angabe: %s\n"
 
-#: src/http.c:158
+#: src/http.c:155
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Verbindung geschlossen.\n"
@@ -351,5 +346,10 @@ msgstr ""
 
 #: src/ssl.c:65
 #, c-format
-msgid "SSL connection failed: %s\n"
+msgid "SSL error: %s\n"
 msgstr ""
+
+#: src/tcp.c:28
+#, fuzzy, c-format
+msgid "Unable to connect to server %s:%i: %s\n"
+msgstr "Keine Verbindung mit %s:%i möglich: %s\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-30 22:57-0300\n"
+"POT-Creation-Date: 2016-03-31 17:29+1100\n"
 "PO-Revision-Date: 2012-03-11 00:03+0900\n"
 "Last-Translator: Osamu Aoki <osamu@debian.org>\n"
 "Language-Team: debian-japanese@lists.debian.org\n"
@@ -59,85 +59,85 @@ msgstr "ローカルファイルをオープンする際にエラー発生しま
 msgid "Starting download"
 msgstr "ダウンロード開始します"
 
-#: src/axel.c:253 src/axel.c:412
+#: src/axel.c:253 src/axel.c:413
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "接続 %i は %s:%i から、インターフェース %s でダウンロードします"
 
-#: src/axel.c:260 src/axel.c:422
+#: src/axel.c:260 src/axel.c:423
 msgid "pthread error!!!"
 msgstr "pthread のエラー!!!"
 
-#: src/axel.c:328
+#: src/axel.c:329
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "接続 %i でエラー! コネクションをクローズしました"
 
-#: src/axel.c:342
+#: src/axel.c:343
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "接続 %i が不意にクローズされました"
 
-#: src/axel.c:346 src/axel.c:363
+#: src/axel.c:347 src/axel.c:364
 #, c-format
 msgid "Connection %i finished"
 msgstr "接続 %i が終了しました"
 
-#: src/axel.c:375
+#: src/axel.c:376
 msgid "Write error!"
 msgstr "書き込みエラー!"
 
-#: src/axel.c:387
+#: src/axel.c:388
 #, c-format
 msgid "Connection %i timed out"
 msgstr "接続 %i がタイムアウトしました"
 
-#: src/conf.c:107
+#: src/conf.c:108
 #, c-format
 msgid "Error in %s line %i.\n"
 msgstr "%s の %i 行目でエラー。\n"
 
-#: src/conn.c:349 src/ftp.c:122
+#: src/conn.c:344 src/ftp.c:119
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "リディレクト回数が多すぎます。\n"
 
-#: src/conn.c:368
+#: src/conn.c:363
 #, c-format
 msgid "Unknown HTTP error.\n"
 msgstr "未知の HTTP エラー。\n"
 
-#: src/ftp.c:33 src/http.c:61
+#: src/ftp.c:33 src/http.c:62
 #, c-format
 msgid "Unable to connect to server %s:%i\n"
 msgstr "サーバー %s:%i に接続できません。\n"
 
-#: src/ftp.c:89
+#: src/ftp.c:86
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "ディレクトリーを %s に変更できません\n"
 
-#: src/ftp.c:115 src/ftp.c:175
+#: src/ftp.c:112 src/ftp.c:171
 #, c-format
 msgid "File not found.\n"
 msgstr "ファイルが見つかりません。\n"
 
-#: src/ftp.c:177
+#: src/ftp.c:173
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "この URL には複数のマッチがあります。\n"
 
-#: src/ftp.c:248 src/ftp.c:254
+#: src/ftp.c:244 src/ftp.c:250
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "受動的データー接続の開始でエラー。\n"
 
-#: src/ftp.c:284
+#: src/ftp.c:280
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "コマンド %s を書く際にエラー\n"
 
-#: src/ftp.c:309 src/http.c:161
+#: src/ftp.c:305 src/http.c:172
 #, c-format
 msgid "Connection gone.\n"
 msgstr "接続が失われています。\n"
@@ -147,70 +147,70 @@ msgstr "接続が失われています。\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "無効なプロキシストリング: %s\n"
 
-#: src/http.c:147
+#: src/http.c:158
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "接続が失われています。\n"
 
-#: src/text.c:156
+#: src/text.c:160
 #, c-format
 msgid "Can't redirect stdout to /dev/null.\n"
 msgstr "標準出力を /dev/null にリディレクトできません。\n"
 
-#: src/text.c:184
+#: src/text.c:189
 #, c-format
 msgid "Error when trying to read URL (Too long?).\n"
 msgstr "URL を読もうとした際に(長すぎ?)エラー。\n"
 
-#: src/text.c:193
+#: src/text.c:198
 #, c-format
 msgid "Can't handle URLs of length over %d\n"
 msgstr "%d を超える長さの URL は取り扱えません\n"
 
-#: src/text.c:198
+#: src/text.c:203
 #, c-format
 msgid "Initializing download: %s\n"
 msgstr "ダウンロードを初期化: %s\n"
 
-#: src/text.c:205
+#: src/text.c:210
 #, c-format
 msgid "Doing search...\n"
 msgstr "サーチ中...\n"
 
-#: src/text.c:209
+#: src/text.c:214
 #, c-format
 msgid "File not found\n"
 msgstr "ファイルが見つかりません\n"
 
-#: src/text.c:213
+#: src/text.c:218
 #, c-format
 msgid "Testing speeds, this can take a while...\n"
 msgstr "スピードをテスト中、時間がかかるかもしれません...\n"
 
-#: src/text.c:218
+#: src/text.c:223
 #, c-format
 msgid "%i usable servers found, will use these URLs:\n"
 msgstr ""
 "使用可能なサーバーが %i つ見つかりましたので、以下の URL を使用します:\n"
 
-#: src/text.c:277
+#: src/text.c:282
 #, c-format
 msgid "Filename too long!\n"
 msgstr "ファイル名が長すぎます!\n"
 
-#: src/text.c:289
+#: src/text.c:294
 #, c-format
 msgid "No state file, cannot resume!\n"
 msgstr "状態ファイルがありませんので、再開できません!\n"
 
-#: src/text.c:294
+#: src/text.c:299
 #, c-format
 msgid "State file found, but no downloaded data. Starting from scratch.\n"
 msgstr ""
 "状態ファイルが見つかったけれど、ダウンロードされたデーターが見つかりません。"
 "最初から始めます。\n"
 
-#: src/text.c:425
+#: src/text.c:430
 #, c-format
 msgid ""
 "\n"
@@ -219,47 +219,47 @@ msgstr ""
 "\n"
 "%s を %s にダウンロード。(%.2f KB/s)\n"
 
-#: src/text.c:447
+#: src/text.c:452
 #, c-format
 msgid "%lld byte"
 msgstr "%lld バイト"
 
-#: src/text.c:449
+#: src/text.c:454
 #, c-format
 msgid "%.1f Kilobyte"
 msgstr "%.1f キロバイト"
 
-#: src/text.c:451
+#: src/text.c:456
 #, c-format
 msgid "%.1f Megabyte"
 msgstr "%.1f メガバイト"
 
-#: src/text.c:453
+#: src/text.c:458
 #, c-format
 msgid "%.1f Gigabyte"
 msgstr "%.1f ギガバイト"
 
-#: src/text.c:462
+#: src/text.c:467
 #, c-format
 msgid "%i second"
 msgstr "%i 秒"
 
-#: src/text.c:464
+#: src/text.c:469
 #, c-format
 msgid "%i seconds"
 msgstr "%i 秒"
 
-#: src/text.c:466
+#: src/text.c:471
 #, fuzzy, c-format
 msgid "%i:%02i minute(s)"
 msgstr "%i:%02i 秒"
 
-#: src/text.c:468
+#: src/text.c:473
 #, fuzzy, c-format
 msgid "%i:%02i:%02i hour(s)"
 msgstr "%i:%02i:%02i 秒"
 
-#: src/text.c:557
+#: src/text.c:562
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -271,6 +271,7 @@ msgid ""
 "-H x\tAdd header string\n"
 "-U x\tSet user agent\n"
 "-N\tJust don't use any proxy server\n"
+"-k\tDon't verify the SSL certificate\n"
 "-q\tLeave stdout alone\n"
 "-v\tMore status information\n"
 "-a\tAlternate progress indicator\n"
@@ -295,7 +296,7 @@ msgstr ""
 "-V\tバージョン情報\n"
 "\n"
 
-#: src/text.c:574
+#: src/text.c:580
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -307,6 +308,7 @@ msgid ""
 "--header=x\t\t-H x\tAdd header string\n"
 "--user-agent=x\t\t-U x\tSet user agent\n"
 "--no-proxy\t\t-N\tJust don't use any proxy server\n"
+"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 "--quiet\t\t\t-q\tLeave stdout alone\n"
 "--verbose\t\t-v\tMore status information\n"
 "--alternate\t\t-a\tAlternate progress indicator\n"
@@ -331,24 +333,29 @@ msgstr ""
 "--version\t\t-V\tバージョン情報\n"
 "\n"
 
-#: src/text.c:595
+#: src/text.c:602
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Axel version %s (%s)\n"
 msgstr "Axel バージョン %s (%s)\n"
 
-#: src/text.c:598
+#: src/text.c:605
 #, c-format
 msgid ""
 "\n"
 "                    and others."
 msgstr ""
 
-#: src/text.c:599
+#: src/text.c:606
 #, c-format
 msgid ""
 "\n"
 "Please, see the CREDITS file.\n"
 "\n"
+msgstr ""
+
+#: src/ssl.c:65
+#, c-format
+msgid "SSL connection failed: %s\n"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-31 17:29+1100\n"
+"POT-Creation-Date: 2016-03-31 21:56+1100\n"
 "PO-Revision-Date: 2012-03-11 00:03+0900\n"
 "Last-Translator: Osamu Aoki <osamu@debian.org>\n"
 "Language-Team: debian-japanese@lists.debian.org\n"
@@ -97,7 +97,7 @@ msgstr "接続 %i がタイムアウトしました"
 msgid "Error in %s line %i.\n"
 msgstr "%s の %i 行目でエラー。\n"
 
-#: src/conn.c:344 src/ftp.c:119
+#: src/conn.c:344 src/ftp.c:117
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "リディレクト回数が多すぎます。\n"
@@ -107,37 +107,32 @@ msgstr "リディレクト回数が多すぎます。\n"
 msgid "Unknown HTTP error.\n"
 msgstr "未知の HTTP エラー。\n"
 
-#: src/ftp.c:33 src/http.c:62
-#, c-format
-msgid "Unable to connect to server %s:%i\n"
-msgstr "サーバー %s:%i に接続できません。\n"
-
-#: src/ftp.c:86
+#: src/ftp.c:84
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "ディレクトリーを %s に変更できません\n"
 
-#: src/ftp.c:112 src/ftp.c:171
+#: src/ftp.c:110 src/ftp.c:169
 #, c-format
 msgid "File not found.\n"
 msgstr "ファイルが見つかりません。\n"
 
-#: src/ftp.c:173
+#: src/ftp.c:171
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "この URL には複数のマッチがあります。\n"
 
-#: src/ftp.c:244 src/ftp.c:250
+#: src/ftp.c:242
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "受動的データー接続の開始でエラー。\n"
 
-#: src/ftp.c:280
+#: src/ftp.c:275
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "コマンド %s を書く際にエラー\n"
 
-#: src/ftp.c:305 src/http.c:172
+#: src/ftp.c:300 src/http.c:169
 #, c-format
 msgid "Connection gone.\n"
 msgstr "接続が失われています。\n"
@@ -147,7 +142,7 @@ msgstr "接続が失われています。\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "無効なプロキシストリング: %s\n"
 
-#: src/http.c:158
+#: src/http.c:155
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "接続が失われています。\n"
@@ -357,5 +352,10 @@ msgstr ""
 
 #: src/ssl.c:65
 #, c-format
-msgid "SSL connection failed: %s\n"
+msgid "SSL error: %s\n"
 msgstr ""
+
+#: src/tcp.c:28
+#, fuzzy, c-format
+msgid "Unable to connect to server %s:%i: %s\n"
+msgstr "サーバー %s:%i に接続できません。%s\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-31 17:29+1100\n"
+"POT-Creation-Date: 2016-03-31 21:56+1100\n"
 "PO-Revision-Date: 2001-11-14 15:22+0200\n"
 "Last-Translator: Wilmer van der Gaast <wilmer@gaast.net>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -93,7 +93,7 @@ msgstr "Time-out op verbinding %i"
 msgid "Error in %s line %i.\n"
 msgstr "Fout in %s regel %i.\n"
 
-#: src/conn.c:344 src/ftp.c:119
+#: src/conn.c:344 src/ftp.c:117
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Te veel redirects.\n"
@@ -103,37 +103,32 @@ msgstr "Te veel redirects.\n"
 msgid "Unknown HTTP error.\n"
 msgstr "Onbekende HTTP fout.\n"
 
-#: src/ftp.c:33 src/http.c:62
-#, c-format
-msgid "Unable to connect to server %s:%i\n"
-msgstr "Kan niet verbinden met server %s:%i\n"
-
-#: src/ftp.c:86
+#: src/ftp.c:84
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr ""
 
-#: src/ftp.c:112 src/ftp.c:171
+#: src/ftp.c:110 src/ftp.c:169
 #, c-format
 msgid "File not found.\n"
 msgstr "Bestand niet gevonden.\n"
 
-#: src/ftp.c:173
+#: src/ftp.c:171
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Meerdere bestanden passen bij deze URL.\n"
 
-#: src/ftp.c:244 src/ftp.c:250
+#: src/ftp.c:242
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Fout bij het openen van een data verbinding.\n"
 
-#: src/ftp.c:280
+#: src/ftp.c:275
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Fout bij het schrijven van commando %s\n"
 
-#: src/ftp.c:305 src/http.c:172
+#: src/ftp.c:300 src/http.c:169
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Verbinding gesloten.\n"
@@ -143,7 +138,7 @@ msgstr "Verbinding gesloten.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "Ongeldige proxy string: %s\n"
 
-#: src/http.c:158
+#: src/http.c:155
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Verbinding gesloten.\n"
@@ -346,5 +341,10 @@ msgstr ""
 
 #: src/ssl.c:65
 #, c-format
-msgid "SSL connection failed: %s\n"
+msgid "SSL error: %s\n"
 msgstr ""
+
+#: src/tcp.c:28
+#, fuzzy, c-format
+msgid "Unable to connect to server %s:%i: %s\n"
+msgstr "Kan niet verbinden met server %s:%i %s\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-30 22:57-0300\n"
+"POT-Creation-Date: 2016-03-31 17:29+1100\n"
 "PO-Revision-Date: 2001-11-14 15:22+0200\n"
 "Last-Translator: Wilmer van der Gaast <wilmer@gaast.net>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -55,85 +55,85 @@ msgstr "Fout bij openen lokaal bestand"
 msgid "Starting download"
 msgstr "Begin download"
 
-#: src/axel.c:253 src/axel.c:412
+#: src/axel.c:253 src/axel.c:413
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Verbinding %i gebruikt server %s:%i via interface %s"
 
-#: src/axel.c:260 src/axel.c:422
+#: src/axel.c:260 src/axel.c:423
 msgid "pthread error!!!"
 msgstr "pthread fout!!!"
 
-#: src/axel.c:328
+#: src/axel.c:329
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Fout op verbinding %i! Verbinding gesloten"
 
-#: src/axel.c:342
+#: src/axel.c:343
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Verbinding %i onverwachts gesloten"
 
-#: src/axel.c:346 src/axel.c:363
+#: src/axel.c:347 src/axel.c:364
 #, c-format
 msgid "Connection %i finished"
 msgstr "Verbinding %i klaar"
 
-#: src/axel.c:375
+#: src/axel.c:376
 msgid "Write error!"
 msgstr "Schrijffout!"
 
-#: src/axel.c:387
+#: src/axel.c:388
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Time-out op verbinding %i"
 
-#: src/conf.c:107
+#: src/conf.c:108
 #, c-format
 msgid "Error in %s line %i.\n"
 msgstr "Fout in %s regel %i.\n"
 
-#: src/conn.c:349 src/ftp.c:122
+#: src/conn.c:344 src/ftp.c:119
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Te veel redirects.\n"
 
-#: src/conn.c:368
+#: src/conn.c:363
 #, c-format
 msgid "Unknown HTTP error.\n"
 msgstr "Onbekende HTTP fout.\n"
 
-#: src/ftp.c:33 src/http.c:61
+#: src/ftp.c:33 src/http.c:62
 #, c-format
 msgid "Unable to connect to server %s:%i\n"
 msgstr "Kan niet verbinden met server %s:%i\n"
 
-#: src/ftp.c:89
+#: src/ftp.c:86
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr ""
 
-#: src/ftp.c:115 src/ftp.c:175
+#: src/ftp.c:112 src/ftp.c:171
 #, c-format
 msgid "File not found.\n"
 msgstr "Bestand niet gevonden.\n"
 
-#: src/ftp.c:177
+#: src/ftp.c:173
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Meerdere bestanden passen bij deze URL.\n"
 
-#: src/ftp.c:248 src/ftp.c:254
+#: src/ftp.c:244 src/ftp.c:250
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Fout bij het openen van een data verbinding.\n"
 
-#: src/ftp.c:284
+#: src/ftp.c:280
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Fout bij het schrijven van commando %s\n"
 
-#: src/ftp.c:309 src/http.c:161
+#: src/ftp.c:305 src/http.c:172
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Verbinding gesloten.\n"
@@ -143,67 +143,67 @@ msgstr "Verbinding gesloten.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "Ongeldige proxy string: %s\n"
 
-#: src/http.c:147
+#: src/http.c:158
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Verbinding gesloten.\n"
 
-#: src/text.c:156
+#: src/text.c:160
 #, c-format
 msgid "Can't redirect stdout to /dev/null.\n"
 msgstr "Fout bij het afsluiten van stdout.\n"
 
-#: src/text.c:184
+#: src/text.c:189
 #, c-format
 msgid "Error when trying to read URL (Too long?).\n"
 msgstr ""
 
-#: src/text.c:193
+#: src/text.c:198
 #, c-format
 msgid "Can't handle URLs of length over %d\n"
 msgstr ""
 
-#: src/text.c:198
+#: src/text.c:203
 #, c-format
 msgid "Initializing download: %s\n"
 msgstr "Begin download: %s\n"
 
-#: src/text.c:205
+#: src/text.c:210
 #, c-format
 msgid "Doing search...\n"
 msgstr "Zoeken...\n"
 
-#: src/text.c:209
+#: src/text.c:214
 #, c-format
 msgid "File not found\n"
 msgstr "Bestand niet gevonden\n"
 
-#: src/text.c:213
+#: src/text.c:218
 #, c-format
 msgid "Testing speeds, this can take a while...\n"
 msgstr "Snelheden testen, dit kan even duren...\n"
 
-#: src/text.c:218
+#: src/text.c:223
 #, c-format
 msgid "%i usable servers found, will use these URLs:\n"
 msgstr "%i bruikbare servers gevonden, de volgende worden gebruikt:\n"
 
-#: src/text.c:277
+#: src/text.c:282
 #, c-format
 msgid "Filename too long!\n"
 msgstr ""
 
-#: src/text.c:289
+#: src/text.c:294
 #, c-format
 msgid "No state file, cannot resume!\n"
 msgstr "Geen .st bestand, kan niet resumen!\n"
 
-#: src/text.c:294
+#: src/text.c:299
 #, c-format
 msgid "State file found, but no downloaded data. Starting from scratch.\n"
 msgstr ".st bestand gevonden maar geen uitvoerbestand. Opnieuw beginnen.\n"
 
-#: src/text.c:425
+#: src/text.c:430
 #, c-format
 msgid ""
 "\n"
@@ -212,47 +212,47 @@ msgstr ""
 "\n"
 "%s gedownload in %s. (%.2f KB/s)\n"
 
-#: src/text.c:447
+#: src/text.c:452
 #, c-format
 msgid "%lld byte"
 msgstr "%lld byte"
 
-#: src/text.c:449
+#: src/text.c:454
 #, c-format
 msgid "%.1f Kilobyte"
 msgstr "%.1f Kilobytes"
 
-#: src/text.c:451
+#: src/text.c:456
 #, c-format
 msgid "%.1f Megabyte"
 msgstr "%.1f Megabytes"
 
-#: src/text.c:453
+#: src/text.c:458
 #, c-format
 msgid "%.1f Gigabyte"
 msgstr "%.1f Gigabytes"
 
-#: src/text.c:462
+#: src/text.c:467
 #, c-format
 msgid "%i second"
 msgstr "%i seconde"
 
-#: src/text.c:464
+#: src/text.c:469
 #, c-format
 msgid "%i seconds"
 msgstr "%i seconden"
 
-#: src/text.c:466
+#: src/text.c:471
 #, fuzzy, c-format
 msgid "%i:%02i minute(s)"
 msgstr "%i:%02i seconden"
 
-#: src/text.c:468
+#: src/text.c:473
 #, fuzzy, c-format
 msgid "%i:%02i:%02i hour(s)"
 msgstr "%i:%02i:%02i seconden"
 
-#: src/text.c:557
+#: src/text.c:562
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -264,6 +264,7 @@ msgid ""
 "-H x\tAdd header string\n"
 "-U x\tSet user agent\n"
 "-N\tJust don't use any proxy server\n"
+"-k\tDon't verify the SSL certificate\n"
 "-q\tLeave stdout alone\n"
 "-v\tMore status information\n"
 "-a\tAlternate progress indicator\n"
@@ -286,7 +287,7 @@ msgstr ""
 "-V\tVersie informatie\n"
 "\n"
 
-#: src/text.c:574
+#: src/text.c:580
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -298,6 +299,7 @@ msgid ""
 "--header=x\t\t-H x\tAdd header string\n"
 "--user-agent=x\t\t-U x\tSet user agent\n"
 "--no-proxy\t\t-N\tJust don't use any proxy server\n"
+"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 "--quiet\t\t\t-q\tLeave stdout alone\n"
 "--verbose\t\t-v\tMore status information\n"
 "--alternate\t\t-a\tAlternate progress indicator\n"
@@ -320,24 +322,29 @@ msgstr ""
 "--version\t\t-V\tVersie informatie\n"
 "\n"
 
-#: src/text.c:595
+#: src/text.c:602
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Axel version %s (%s)\n"
 msgstr "Axel versie %s (%s)\n"
 
-#: src/text.c:598
+#: src/text.c:605
 #, c-format
 msgid ""
 "\n"
 "                    and others."
 msgstr ""
 
-#: src/text.c:599
+#: src/text.c:606
 #, c-format
 msgid ""
 "\n"
 "Please, see the CREDITS file.\n"
 "\n"
+msgstr ""
+
+#: src/ssl.c:65
+#, c-format
+msgid "SSL connection failed: %s\n"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: axel 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-30 22:57-0300\n"
+"POT-Creation-Date: 2016-03-31 17:29+1100\n"
 "PO-Revision-Date: 2016-03-19 13:32-0300\n"
 "Last-Translator: Eriberto Mota <eriberto@eriberto.pro.br>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -61,85 +61,85 @@ msgstr "Erro ao criar o arquivo local"
 msgid "Starting download"
 msgstr "Iniciando o download"
 
-#: src/axel.c:253 src/axel.c:412
+#: src/axel.c:253 src/axel.c:413
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Conexão %i baixando a partir de %s:%i, usando interface %s"
 
-#: src/axel.c:260 src/axel.c:422
+#: src/axel.c:260 src/axel.c:423
 msgid "pthread error!!!"
 msgstr "pthread error!!!"
 
-#: src/axel.c:328
+#: src/axel.c:329
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Erro na conexão %i! Conexão fechada."
 
-#: src/axel.c:342
+#: src/axel.c:343
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Conexão %i fechada inesperadamente"
 
-#: src/axel.c:346 src/axel.c:363
+#: src/axel.c:347 src/axel.c:364
 #, c-format
 msgid "Connection %i finished"
 msgstr "Conexão %i finalizada"
 
-#: src/axel.c:375
+#: src/axel.c:376
 msgid "Write error!"
 msgstr "Erro de escrita!"
 
-#: src/axel.c:387
+#: src/axel.c:388
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Tempo esgotado para a conexão %i"
 
-#: src/conf.c:107
+#: src/conf.c:108
 #, c-format
 msgid "Error in %s line %i.\n"
 msgstr "Erro em %s linha %i.\n"
 
-#: src/conn.c:349 src/ftp.c:122
+#: src/conn.c:344 src/ftp.c:119
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Redirecionamentos excessivos.\n"
 
-#: src/conn.c:368
+#: src/conn.c:363
 #, c-format
 msgid "Unknown HTTP error.\n"
 msgstr "Erro HTTP desconhecido.\n"
 
-#: src/ftp.c:33 src/http.c:61
+#: src/ftp.c:33 src/http.c:62
 #, c-format
 msgid "Unable to connect to server %s:%i\n"
 msgstr "Não consigo conectar o servidor %s:%i\n"
 
-#: src/ftp.c:89
+#: src/ftp.c:86
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "Não consigo ir para o diretório %s\n"
 
-#: src/ftp.c:115 src/ftp.c:175
+#: src/ftp.c:112 src/ftp.c:171
 #, c-format
 msgid "File not found.\n"
 msgstr "Arquivo não encontrado.\n"
 
-#: src/ftp.c:177
+#: src/ftp.c:173
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Muitas possibilidades (matches) para esta URL.\n"
 
-#: src/ftp.c:248 src/ftp.c:254
+#: src/ftp.c:244 src/ftp.c:250
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Erro ao abrir conexão passiva.\n"
 
-#: src/ftp.c:284
+#: src/ftp.c:280
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Erro ao escrever comando %s\n"
 
-#: src/ftp.c:309 src/http.c:161
+#: src/ftp.c:305 src/http.c:172
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Conexão perdida.\n"
@@ -149,69 +149,69 @@ msgstr "Conexão perdida.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "String de proxy inválida: %s\n"
 
-#: src/http.c:147
+#: src/http.c:158
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Conexão perdida enquanto escrevia no disco.\n"
 
-#: src/text.c:156
+#: src/text.c:160
 #, c-format
 msgid "Can't redirect stdout to /dev/null.\n"
 msgstr "Não posso redirecionar a saída padrão para /dev/null.\n"
 
-#: src/text.c:184
+#: src/text.c:189
 #, c-format
 msgid "Error when trying to read URL (Too long?).\n"
 msgstr "Erro ao tentar ler a URL (muito longa?).\n"
 
-#: src/text.c:193
+#: src/text.c:198
 #, c-format
 msgid "Can't handle URLs of length over %d\n"
 msgstr "Não posso manipular URLs com tamanho superior a %d\n"
 
-#: src/text.c:198
+#: src/text.c:203
 #, c-format
 msgid "Initializing download: %s\n"
 msgstr "Inicializando download: %s\n"
 
-#: src/text.c:205
+#: src/text.c:210
 #, c-format
 msgid "Doing search...\n"
 msgstr "Procurando...\n"
 
-#: src/text.c:209
+#: src/text.c:214
 #, c-format
 msgid "File not found\n"
 msgstr "Arquivo não encontrado\n"
 
-#: src/text.c:213
+#: src/text.c:218
 #, c-format
 msgid "Testing speeds, this can take a while...\n"
 msgstr "Testando velocidades. Isso pode demorar um pouco...\n"
 
-#: src/text.c:218
+#: src/text.c:223
 #, c-format
 msgid "%i usable servers found, will use these URLs:\n"
 msgstr "%i servidores possíveis encontrados. Serão utilizadas essas URLs:\n"
 
-#: src/text.c:277
+#: src/text.c:282
 #, c-format
 msgid "Filename too long!\n"
 msgstr "Nome de arquivo muito longo!\n"
 
-#: src/text.c:289
+#: src/text.c:294
 #, c-format
 msgid "No state file, cannot resume!\n"
 msgstr "Estado do arquivo não encontrado. Não posso reiniciar!\n"
 
-#: src/text.c:294
+#: src/text.c:299
 #, c-format
 msgid "State file found, but no downloaded data. Starting from scratch.\n"
 msgstr ""
 "Estado do arquivo encontrado mas não há dados de download. Iniciando do "
 "zero.\n"
 
-#: src/text.c:425
+#: src/text.c:430
 #, c-format
 msgid ""
 "\n"
@@ -220,48 +220,48 @@ msgstr ""
 "\n"
 "Baixados %s em %s. (%.2f KB/s)\n"
 
-#: src/text.c:447
+#: src/text.c:452
 #, c-format
 msgid "%lld byte"
 msgstr "%lld byte(s)"
 
-#: src/text.c:449
+#: src/text.c:454
 #, c-format
 msgid "%.1f Kilobyte"
 msgstr "%.1f Kilobyte(s)"
 
-#: src/text.c:451
+#: src/text.c:456
 #, c-format
 msgid "%.1f Megabyte"
 msgstr "%.1f Megabyte(s)"
 
-#: src/text.c:453
+#: src/text.c:458
 #, c-format
 msgid "%.1f Gigabyte"
 msgstr "%.1f Gigabyte(s)"
 
-#: src/text.c:462
+#: src/text.c:467
 #, c-format
 msgid "%i second"
 msgstr "%i segundo"
 
-#: src/text.c:464
+#: src/text.c:469
 #, c-format
 msgid "%i seconds"
 msgstr "%i segundos"
 
-#: src/text.c:466
+#: src/text.c:471
 #, c-format
 msgid "%i:%02i minute(s)"
 msgstr "%i:%02i minuto(s)"
 
-#: src/text.c:468
+#: src/text.c:473
 #, c-format
 msgid "%i:%02i:%02i hour(s)"
 msgstr "%i:%02i:%02i hora(s)"
 
-#: src/text.c:557
-#, c-format
+#: src/text.c:562
+#, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
 "\n"
@@ -272,6 +272,7 @@ msgid ""
 "-H x\tAdd header string\n"
 "-U x\tSet user agent\n"
 "-N\tJust don't use any proxy server\n"
+"-k\tDon't verify the SSL certificate\n"
 "-q\tLeave stdout alone\n"
 "-v\tMore status information\n"
 "-a\tAlternate progress indicator\n"
@@ -297,8 +298,8 @@ msgstr ""
 "\n"
 "Visite https://github.com/eribertomota/axel/issues\n"
 
-#: src/text.c:574
-#, c-format
+#: src/text.c:580
+#, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
 "\n"
@@ -309,6 +310,7 @@ msgid ""
 "--header=x\t\t-H x\tAdd header string\n"
 "--user-agent=x\t\t-U x\tSet user agent\n"
 "--no-proxy\t\t-N\tJust don't use any proxy server\n"
+"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 "--quiet\t\t\t-q\tLeave stdout alone\n"
 "--verbose\t\t-v\tMore status information\n"
 "--alternate\t\t-a\tAlternate progress indicator\n"
@@ -335,7 +337,7 @@ msgstr ""
 "\n"
 "Visite https://github.com/eribertomota/axel/issues to report bugs\n"
 
-#: src/text.c:595
+#: src/text.c:602
 #, c-format
 msgid ""
 "\n"
@@ -344,7 +346,7 @@ msgstr ""
 "\n"
 "Axel versão %s (%s)\n"
 
-#: src/text.c:598
+#: src/text.c:605
 #, c-format
 msgid ""
 "\n"
@@ -353,7 +355,7 @@ msgstr ""
 "\n"
 "                    e outros."
 
-#: src/text.c:599
+#: src/text.c:606
 #, c-format
 msgid ""
 "\n"
@@ -362,3 +364,8 @@ msgid ""
 msgstr ""
 "\n"
 "Por favor, veja o arquivo CREDITS.\n"
+
+#: src/ssl.c:65
+#, c-format
+msgid "SSL connection failed: %s\n"
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: axel 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-31 17:29+1100\n"
+"POT-Creation-Date: 2016-03-31 21:56+1100\n"
 "PO-Revision-Date: 2016-03-19 13:32-0300\n"
 "Last-Translator: Eriberto Mota <eriberto@eriberto.pro.br>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -99,7 +99,7 @@ msgstr "Tempo esgotado para a conexão %i"
 msgid "Error in %s line %i.\n"
 msgstr "Erro em %s linha %i.\n"
 
-#: src/conn.c:344 src/ftp.c:119
+#: src/conn.c:344 src/ftp.c:117
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Redirecionamentos excessivos.\n"
@@ -109,37 +109,32 @@ msgstr "Redirecionamentos excessivos.\n"
 msgid "Unknown HTTP error.\n"
 msgstr "Erro HTTP desconhecido.\n"
 
-#: src/ftp.c:33 src/http.c:62
-#, c-format
-msgid "Unable to connect to server %s:%i\n"
-msgstr "Não consigo conectar o servidor %s:%i\n"
-
-#: src/ftp.c:86
+#: src/ftp.c:84
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "Não consigo ir para o diretório %s\n"
 
-#: src/ftp.c:112 src/ftp.c:171
+#: src/ftp.c:110 src/ftp.c:169
 #, c-format
 msgid "File not found.\n"
 msgstr "Arquivo não encontrado.\n"
 
-#: src/ftp.c:173
+#: src/ftp.c:171
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Muitas possibilidades (matches) para esta URL.\n"
 
-#: src/ftp.c:244 src/ftp.c:250
+#: src/ftp.c:242
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Erro ao abrir conexão passiva.\n"
 
-#: src/ftp.c:280
+#: src/ftp.c:275
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Erro ao escrever comando %s\n"
 
-#: src/ftp.c:305 src/http.c:172
+#: src/ftp.c:300 src/http.c:169
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Conexão perdida.\n"
@@ -149,7 +144,7 @@ msgstr "Conexão perdida.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "String de proxy inválida: %s\n"
 
-#: src/http.c:158
+#: src/http.c:155
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Conexão perdida enquanto escrevia no disco.\n"
@@ -367,5 +362,10 @@ msgstr ""
 
 #: src/ssl.c:65
 #, c-format
-msgid "SSL connection failed: %s\n"
+msgid "SSL error: %s\n"
 msgstr ""
+
+#: src/tcp.c:28
+#, fuzzy, c-format
+msgid "Unable to connect to server %s:%i: %s\n"
+msgstr "Não consigo conectar o servidor %s:%i %s\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-30 22:57-0300\n"
+"POT-Creation-Date: 2016-03-31 17:29+1100\n"
 "PO-Revision-Date: 2009-04-02 00:05+0200\n"
 "Last-Translator: newhren <colimit@gmail.com>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -56,85 +56,85 @@ msgstr "Ошибка при открытии локального файла"
 msgid "Starting download"
 msgstr "Начинаем скачивание"
 
-#: src/axel.c:253 src/axel.c:412
+#: src/axel.c:253 src/axel.c:413
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Соединение %i скачивает с %s:%i через интерфейс %s"
 
-#: src/axel.c:260 src/axel.c:422
+#: src/axel.c:260 src/axel.c:423
 msgid "pthread error!!!"
 msgstr "ошибка pthread!!!"
 
-#: src/axel.c:328
+#: src/axel.c:329
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Ошибка в соединении %i! Соединение закрыто"
 
-#: src/axel.c:342
+#: src/axel.c:343
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Соединение %i неожиданно закрылось"
 
-#: src/axel.c:346 src/axel.c:363
+#: src/axel.c:347 src/axel.c:364
 #, c-format
 msgid "Connection %i finished"
 msgstr "Соединение %i закончилось"
 
-#: src/axel.c:375
+#: src/axel.c:376
 msgid "Write error!"
 msgstr "Ошибка записи!"
 
-#: src/axel.c:387
+#: src/axel.c:388
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Время соединения %i вышло"
 
-#: src/conf.c:107
+#: src/conf.c:108
 #, c-format
 msgid "Error in %s line %i.\n"
 msgstr "Ошибка в файле %s линия %i.\n"
 
-#: src/conn.c:349 src/ftp.c:122
+#: src/conn.c:344 src/ftp.c:119
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Слишком много перенаправлений.\n"
 
-#: src/conn.c:368
+#: src/conn.c:363
 #, c-format
 msgid "Unknown HTTP error.\n"
 msgstr "Неизвестная ошибка HTTP.\n"
 
-#: src/ftp.c:33 src/http.c:61
+#: src/ftp.c:33 src/http.c:62
 #, c-format
 msgid "Unable to connect to server %s:%i\n"
 msgstr "Невозможно подсоединиться к серверу %s:%i\n"
 
-#: src/ftp.c:89
+#: src/ftp.c:86
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "Невозможно сменить директорию на %s\n"
 
-#: src/ftp.c:115 src/ftp.c:175
+#: src/ftp.c:112 src/ftp.c:171
 #, c-format
 msgid "File not found.\n"
 msgstr "Файл не найден.\n"
 
-#: src/ftp.c:177
+#: src/ftp.c:173
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Несколько совпадений для этого URL.\n"
 
-#: src/ftp.c:248 src/ftp.c:254
+#: src/ftp.c:244 src/ftp.c:250
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Ошибка открытия пассивного соединения.\n"
 
-#: src/ftp.c:284
+#: src/ftp.c:280
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Ошибка записи команды %s\n"
 
-#: src/ftp.c:309 src/http.c:161
+#: src/ftp.c:305 src/http.c:172
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Соединение пропало.\n"
@@ -144,69 +144,69 @@ msgstr "Соединение пропало.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "Некорректная стока прокси: %s\n"
 
-#: src/http.c:147
+#: src/http.c:158
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Соединение пропало.\n"
 
-#: src/text.c:156
+#: src/text.c:160
 #, c-format
 msgid "Can't redirect stdout to /dev/null.\n"
 msgstr "Невозможно перенаправить stdout в /dev/null.\n"
 
-#: src/text.c:184
+#: src/text.c:189
 #, c-format
 msgid "Error when trying to read URL (Too long?).\n"
 msgstr ""
 
-#: src/text.c:193
+#: src/text.c:198
 #, c-format
 msgid "Can't handle URLs of length over %d\n"
 msgstr "URLs длинной больше %d не поддерживаются\n"
 
-#: src/text.c:198
+#: src/text.c:203
 #, c-format
 msgid "Initializing download: %s\n"
 msgstr "Начинаю скачивание: %s\n"
 
-#: src/text.c:205
+#: src/text.c:210
 #, c-format
 msgid "Doing search...\n"
 msgstr "Ищем...\n"
 
-#: src/text.c:209
+#: src/text.c:214
 #, c-format
 msgid "File not found\n"
 msgstr "Файл не найден\n"
 
-#: src/text.c:213
+#: src/text.c:218
 #, c-format
 msgid "Testing speeds, this can take a while...\n"
 msgstr "Пробуем скорости, это может занять некоторое время...\n"
 
-#: src/text.c:218
+#: src/text.c:223
 #, c-format
 msgid "%i usable servers found, will use these URLs:\n"
 msgstr "Найдено %i полезных серверов, будут использованы следующие URLs:\n"
 
-#: src/text.c:277
+#: src/text.c:282
 #, c-format
 msgid "Filename too long!\n"
 msgstr ""
 
-#: src/text.c:289
+#: src/text.c:294
 #, c-format
 msgid "No state file, cannot resume!\n"
 msgstr "Файл состояния не найден, возобновление невозможно!\n"
 
-#: src/text.c:294
+#: src/text.c:299
 #, c-format
 msgid "State file found, but no downloaded data. Starting from scratch.\n"
 msgstr ""
 "Файл состояния найден, но предварительно скачанные данные отсутствуют. "
 "Начинаем заново.\n"
 
-#: src/text.c:425
+#: src/text.c:430
 #, c-format
 msgid ""
 "\n"
@@ -215,47 +215,47 @@ msgstr ""
 "\n"
 "%s скачано за %s. (%.2f КБ/с)\n"
 
-#: src/text.c:447
+#: src/text.c:452
 #, c-format
 msgid "%lld byte"
 msgstr "%lld байт"
 
-#: src/text.c:449
+#: src/text.c:454
 #, c-format
 msgid "%.1f Kilobyte"
 msgstr "%.1f килобайта(ов)"
 
-#: src/text.c:451
+#: src/text.c:456
 #, c-format
 msgid "%.1f Megabyte"
 msgstr "%.1f мегабайта(ов)"
 
-#: src/text.c:453
+#: src/text.c:458
 #, fuzzy, c-format
 msgid "%.1f Gigabyte"
 msgstr "%.1f мегабайта(ов)"
 
-#: src/text.c:462
+#: src/text.c:467
 #, c-format
 msgid "%i second"
 msgstr "%i секунда"
 
-#: src/text.c:464
+#: src/text.c:469
 #, c-format
 msgid "%i seconds"
 msgstr "%i секунд(ы)"
 
-#: src/text.c:466
+#: src/text.c:471
 #, fuzzy, c-format
 msgid "%i:%02i minute(s)"
 msgstr "%i:%02i секунд(ы)"
 
-#: src/text.c:468
+#: src/text.c:473
 #, fuzzy, c-format
 msgid "%i:%02i:%02i hour(s)"
 msgstr "%i:%02i:%02i секунд(ы)"
 
-#: src/text.c:557
+#: src/text.c:562
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -267,6 +267,7 @@ msgid ""
 "-H x\tAdd header string\n"
 "-U x\tSet user agent\n"
 "-N\tJust don't use any proxy server\n"
+"-k\tDon't verify the SSL certificate\n"
 "-q\tLeave stdout alone\n"
 "-v\tMore status information\n"
 "-a\tAlternate progress indicator\n"
@@ -289,8 +290,8 @@ msgstr ""
 "-V\tИнформация о версии\n"
 "\n"
 
-#: src/text.c:574
-#, c-format
+#: src/text.c:580
+#, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
 "\n"
@@ -301,6 +302,7 @@ msgid ""
 "--header=x\t\t-H x\tAdd header string\n"
 "--user-agent=x\t\t-U x\tSet user agent\n"
 "--no-proxy\t\t-N\tJust don't use any proxy server\n"
+"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 "--quiet\t\t\t-q\tLeave stdout alone\n"
 "--verbose\t\t-v\tMore status information\n"
 "--alternate\t\t-a\tAlternate progress indicator\n"
@@ -323,24 +325,29 @@ msgstr ""
 "--version\t\t-V\tИнформация о версии\n"
 "\n"
 
-#: src/text.c:595
+#: src/text.c:602
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Axel version %s (%s)\n"
 msgstr "Axel, версия %s (%s)\n"
 
-#: src/text.c:598
+#: src/text.c:605
 #, c-format
 msgid ""
 "\n"
 "                    and others."
 msgstr ""
 
-#: src/text.c:599
+#: src/text.c:606
 #, c-format
 msgid ""
 "\n"
 "Please, see the CREDITS file.\n"
 "\n"
+msgstr ""
+
+#: src/ssl.c:65
+#, c-format
+msgid "SSL connection failed: %s\n"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-31 17:29+1100\n"
+"POT-Creation-Date: 2016-03-31 21:56+1100\n"
 "PO-Revision-Date: 2009-04-02 00:05+0200\n"
 "Last-Translator: newhren <colimit@gmail.com>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -94,7 +94,7 @@ msgstr "Время соединения %i вышло"
 msgid "Error in %s line %i.\n"
 msgstr "Ошибка в файле %s линия %i.\n"
 
-#: src/conn.c:344 src/ftp.c:119
+#: src/conn.c:344 src/ftp.c:117
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "Слишком много перенаправлений.\n"
@@ -104,37 +104,32 @@ msgstr "Слишком много перенаправлений.\n"
 msgid "Unknown HTTP error.\n"
 msgstr "Неизвестная ошибка HTTP.\n"
 
-#: src/ftp.c:33 src/http.c:62
-#, c-format
-msgid "Unable to connect to server %s:%i\n"
-msgstr "Невозможно подсоединиться к серверу %s:%i\n"
-
-#: src/ftp.c:86
+#: src/ftp.c:84
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "Невозможно сменить директорию на %s\n"
 
-#: src/ftp.c:112 src/ftp.c:171
+#: src/ftp.c:110 src/ftp.c:169
 #, c-format
 msgid "File not found.\n"
 msgstr "Файл не найден.\n"
 
-#: src/ftp.c:173
+#: src/ftp.c:171
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "Несколько совпадений для этого URL.\n"
 
-#: src/ftp.c:244 src/ftp.c:250
+#: src/ftp.c:242
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "Ошибка открытия пассивного соединения.\n"
 
-#: src/ftp.c:280
+#: src/ftp.c:275
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "Ошибка записи команды %s\n"
 
-#: src/ftp.c:305 src/http.c:172
+#: src/ftp.c:300 src/http.c:169
 #, c-format
 msgid "Connection gone.\n"
 msgstr "Соединение пропало.\n"
@@ -144,7 +139,7 @@ msgstr "Соединение пропало.\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "Некорректная стока прокси: %s\n"
 
-#: src/http.c:158
+#: src/http.c:155
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "Соединение пропало.\n"
@@ -349,5 +344,10 @@ msgstr ""
 
 #: src/ssl.c:65
 #, c-format
-msgid "SSL connection failed: %s\n"
+msgid "SSL error: %s\n"
 msgstr ""
+
+#: src/tcp.c:28
+#, fuzzy, c-format
+msgid "Unable to connect to server %s:%i: %s\n"
+msgstr "Невозможно подсоединиться к серверу %s:%i: %s\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-31 17:29+1100\n"
+"POT-Creation-Date: 2016-03-31 21:56+1100\n"
 "PO-Revision-Date: 2008-11-08 22:40+0700\n"
 "Last-Translator: Shuge Lee <shuge.lee@gmail.com>\n"
 "Language-Team: Simplified Chinese <i18n-zh@i18n.org>\n"
@@ -96,7 +96,7 @@ msgstr "连接超时 %i"
 msgid "Error in %s line %i.\n"
 msgstr "%s %i 行有错误。\n"
 
-#: src/conn.c:344 src/ftp.c:119
+#: src/conn.c:344 src/ftp.c:117
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "太多重定向。\n"
@@ -106,37 +106,32 @@ msgstr "太多重定向。\n"
 msgid "Unknown HTTP error.\n"
 msgstr "未知 HTTP 错误。\n"
 
-#: src/ftp.c:33 src/http.c:62
-#, c-format
-msgid "Unable to connect to server %s:%i\n"
-msgstr "不能连接到服务器 %s:%i\n"
-
-#: src/ftp.c:86
+#: src/ftp.c:84
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "不能变更目录到 %s\n"
 
-#: src/ftp.c:112 src/ftp.c:171
+#: src/ftp.c:110 src/ftp.c:169
 #, c-format
 msgid "File not found.\n"
 msgstr "找不到文件。\n"
 
-#: src/ftp.c:173
+#: src/ftp.c:171
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "这个 URL 有多个匹配。\n"
 
-#: src/ftp.c:244 src/ftp.c:250
+#: src/ftp.c:242
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "打开主动数据连接错误。\n"
 
-#: src/ftp.c:280
+#: src/ftp.c:275
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "写命令出错 %s\n"
 
-#: src/ftp.c:305 src/http.c:172
+#: src/ftp.c:300 src/http.c:169
 #, c-format
 msgid "Connection gone.\n"
 msgstr "连接继续。\n"
@@ -146,7 +141,7 @@ msgstr "连接继续。\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "代理字符串无效： %s\n"
 
-#: src/http.c:158
+#: src/http.c:155
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "连接继续。\n"
@@ -349,5 +344,10 @@ msgstr ""
 
 #: src/ssl.c:65
 #, c-format
-msgid "SSL connection failed: %s\n"
+msgid "SSL error: %s\n"
 msgstr ""
+
+#: src/tcp.c:28
+#, fuzzy, c-format
+msgid "Unable to connect to server %s:%i: %s\n"
+msgstr "不能连接到服务器 %s:%i: %s\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Axel\n"
 "Report-Msgid-Bugs-To: https://github.com/eribertomota/axel/issues\n"
-"POT-Creation-Date: 2016-03-30 22:57-0300\n"
+"POT-Creation-Date: 2016-03-31 17:29+1100\n"
 "PO-Revision-Date: 2008-11-08 22:40+0700\n"
 "Last-Translator: Shuge Lee <shuge.lee@gmail.com>\n"
 "Language-Team: Simplified Chinese <i18n-zh@i18n.org>\n"
@@ -58,85 +58,85 @@ msgstr "打开本地文件错误"
 msgid "Starting download"
 msgstr "开始下载"
 
-#: src/axel.c:253 src/axel.c:412
+#: src/axel.c:253 src/axel.c:413
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "连接 %i 从 %s:%i 通过接口 %s 下载"
 
-#: src/axel.c:260 src/axel.c:422
+#: src/axel.c:260 src/axel.c:423
 msgid "pthread error!!!"
 msgstr "线程错误！！！"
 
-#: src/axel.c:328
+#: src/axel.c:329
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "连接 %i 有错误！ 连接中断"
 
-#: src/axel.c:342
+#: src/axel.c:343
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "连接 %i 被异常中断"
 
-#: src/axel.c:346 src/axel.c:363
+#: src/axel.c:347 src/axel.c:364
 #, c-format
 msgid "Connection %i finished"
 msgstr "连接 %i 结束"
 
-#: src/axel.c:375
+#: src/axel.c:376
 msgid "Write error!"
 msgstr "写错误！"
 
-#: src/axel.c:387
+#: src/axel.c:388
 #, c-format
 msgid "Connection %i timed out"
 msgstr "连接超时 %i"
 
-#: src/conf.c:107
+#: src/conf.c:108
 #, c-format
 msgid "Error in %s line %i.\n"
 msgstr "%s %i 行有错误。\n"
 
-#: src/conn.c:349 src/ftp.c:122
+#: src/conn.c:344 src/ftp.c:119
 #, c-format
 msgid "Too many redirects.\n"
 msgstr "太多重定向。\n"
 
-#: src/conn.c:368
+#: src/conn.c:363
 #, c-format
 msgid "Unknown HTTP error.\n"
 msgstr "未知 HTTP 错误。\n"
 
-#: src/ftp.c:33 src/http.c:61
+#: src/ftp.c:33 src/http.c:62
 #, c-format
 msgid "Unable to connect to server %s:%i\n"
 msgstr "不能连接到服务器 %s:%i\n"
 
-#: src/ftp.c:89
+#: src/ftp.c:86
 #, c-format
 msgid "Can't change directory to %s\n"
 msgstr "不能变更目录到 %s\n"
 
-#: src/ftp.c:115 src/ftp.c:175
+#: src/ftp.c:112 src/ftp.c:171
 #, c-format
 msgid "File not found.\n"
 msgstr "找不到文件。\n"
 
-#: src/ftp.c:177
+#: src/ftp.c:173
 #, c-format
 msgid "Multiple matches for this URL.\n"
 msgstr "这个 URL 有多个匹配。\n"
 
-#: src/ftp.c:248 src/ftp.c:254
+#: src/ftp.c:244 src/ftp.c:250
 #, c-format
 msgid "Error opening passive data connection.\n"
 msgstr "打开主动数据连接错误。\n"
 
-#: src/ftp.c:284
+#: src/ftp.c:280
 #, c-format
 msgid "Error writing command %s\n"
 msgstr "写命令出错 %s\n"
 
-#: src/ftp.c:309 src/http.c:161
+#: src/ftp.c:305 src/http.c:172
 #, c-format
 msgid "Connection gone.\n"
 msgstr "连接继续。\n"
@@ -146,67 +146,67 @@ msgstr "连接继续。\n"
 msgid "Invalid proxy string: %s\n"
 msgstr "代理字符串无效： %s\n"
 
-#: src/http.c:147
+#: src/http.c:158
 #, fuzzy, c-format
 msgid "Connection gone while writing.\n"
 msgstr "连接继续。\n"
 
-#: src/text.c:156
+#: src/text.c:160
 #, c-format
 msgid "Can't redirect stdout to /dev/null.\n"
 msgstr "stdout 不能重定向到 /dev/null 。\n"
 
-#: src/text.c:184
+#: src/text.c:189
 #, c-format
 msgid "Error when trying to read URL (Too long?).\n"
 msgstr ""
 
-#: src/text.c:193
+#: src/text.c:198
 #, c-format
 msgid "Can't handle URLs of length over %d\n"
 msgstr "不能处理长度超过 %d 的URLs\n"
 
-#: src/text.c:198
+#: src/text.c:203
 #, c-format
 msgid "Initializing download: %s\n"
 msgstr "初始化下载: %s\n"
 
-#: src/text.c:205
+#: src/text.c:210
 #, c-format
 msgid "Doing search...\n"
 msgstr "进行搜索中...\n"
 
-#: src/text.c:209
+#: src/text.c:214
 #, c-format
 msgid "File not found\n"
 msgstr "文件找不到\n"
 
-#: src/text.c:213
+#: src/text.c:218
 #, c-format
 msgid "Testing speeds, this can take a while...\n"
 msgstr "c测试速度，这可能有点费时……\n"
 
-#: src/text.c:218
+#: src/text.c:223
 #, c-format
 msgid "%i usable servers found, will use these URLs:\n"
 msgstr "%i 可用的服务器没有找到，将使用这些 URLs ：\n"
 
-#: src/text.c:277
+#: src/text.c:282
 #, c-format
 msgid "Filename too long!\n"
 msgstr ""
 
-#: src/text.c:289
+#: src/text.c:294
 #, c-format
 msgid "No state file, cannot resume!\n"
 msgstr "没有状态文件，无法恢复！\n"
 
-#: src/text.c:294
+#: src/text.c:299
 #, c-format
 msgid "State file found, but no downloaded data. Starting from scratch.\n"
 msgstr "找到状态文件，但没有已下载数据。重新开始。\n"
 
-#: src/text.c:425
+#: src/text.c:430
 #, c-format
 msgid ""
 "\n"
@@ -215,47 +215,47 @@ msgstr ""
 "\n"
 "%s 已下载，用时 %s。（%.2f 千字节/秒）\n"
 
-#: src/text.c:447
+#: src/text.c:452
 #, c-format
 msgid "%lld byte"
 msgstr "%lld 字节"
 
-#: src/text.c:449
+#: src/text.c:454
 #, c-format
 msgid "%.1f Kilobyte"
 msgstr "%.1f 千字节"
 
-#: src/text.c:451
+#: src/text.c:456
 #, fuzzy, c-format
 msgid "%.1f Megabyte"
 msgstr "%.1f 兆字节"
 
-#: src/text.c:453
+#: src/text.c:458
 #, fuzzy, c-format
 msgid "%.1f Gigabyte"
 msgstr "%.1f 兆字节"
 
-#: src/text.c:462
+#: src/text.c:467
 #, c-format
 msgid "%i second"
 msgstr "%i 秒"
 
-#: src/text.c:464
+#: src/text.c:469
 #, c-format
 msgid "%i seconds"
 msgstr "%i 秒"
 
-#: src/text.c:466
+#: src/text.c:471
 #, fuzzy, c-format
 msgid "%i:%02i minute(s)"
 msgstr "%i:%02i 秒"
 
-#: src/text.c:468
+#: src/text.c:473
 #, fuzzy, c-format
 msgid "%i:%02i:%02i hour(s)"
 msgstr "%i:%02i:%02i 秒"
 
-#: src/text.c:557
+#: src/text.c:562
 #, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
@@ -267,6 +267,7 @@ msgid ""
 "-H x\tAdd header string\n"
 "-U x\tSet user agent\n"
 "-N\tJust don't use any proxy server\n"
+"-k\tDon't verify the SSL certificate\n"
 "-q\tLeave stdout alone\n"
 "-v\tMore status information\n"
 "-a\tAlternate progress indicator\n"
@@ -289,8 +290,8 @@ msgstr ""
 "-V\t版本信息\n"
 "\n"
 
-#: src/text.c:574
-#, c-format
+#: src/text.c:580
+#, fuzzy, c-format
 msgid ""
 "Usage: axel [options] url1 [url2] [url...]\n"
 "\n"
@@ -301,6 +302,7 @@ msgid ""
 "--header=x\t\t-H x\tAdd header string\n"
 "--user-agent=x\t\t-U x\tSet user agent\n"
 "--no-proxy\t\t-N\tJust don't use any proxy server\n"
+"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 "--quiet\t\t\t-q\tLeave stdout alone\n"
 "--verbose\t\t-v\tMore status information\n"
 "--alternate\t\t-a\tAlternate progress indicator\n"
@@ -323,24 +325,29 @@ msgstr ""
 "--version\t\t-V\t版本信息\n"
 "\n"
 
-#: src/text.c:595
+#: src/text.c:602
 #, fuzzy, c-format
 msgid ""
 "\n"
 "Axel version %s (%s)\n"
 msgstr "Axel 版本 %s (%s)\n"
 
-#: src/text.c:598
+#: src/text.c:605
 #, c-format
 msgid ""
 "\n"
 "                    and others."
 msgstr ""
 
-#: src/text.c:599
+#: src/text.c:606
 #, c-format
 msgid ""
 "\n"
 "Please, see the CREDITS file.\n"
 "\n"
+msgstr ""
+
+#: src/ssl.c:65
+#, c-format
+msgid "SSL connection failed: %s\n"
 msgstr ""

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
 bin_PROGRAMS = axel
-axel_SOURCES = axel.c conf.c conn.c ftp.c http.c search.c tcp.c text.c
+axel_SOURCES = axel.c conf.c conn.c ftp.c http.c search.c ssl.c tcp.c text.c
 
 AM_CPPFLAGS = -DLOCALEDIR=\""$(localedir)"\"

--- a/src/axel.c
+++ b/src/axel.c
@@ -291,9 +291,10 @@ void axel_do( axel_t *axel )
 	hifd = 0;
 	for( i = 0; i < axel->conf->num_connections; i ++ )
 	{
-		if( axel->conn[i].enabled )
-			FD_SET( axel->conn[i].fd, fds );
-		hifd = max( hifd, axel->conn[i].fd );
+		if( axel->conn[i].enabled ) {
+			FD_SET( axel->conn[i].tcp->fd, fds );
+			hifd = max( hifd, axel->conn[i].tcp->fd );
+		}
 	}
 	if( hifd == 0 )
 	{
@@ -317,10 +318,10 @@ void axel_do( axel_t *axel )
 	/* Handle connections which need attention */
 	for( i = 0; i < axel->conf->num_connections; i ++ )
 	if( axel->conn[i].enabled ) {
-	if( FD_ISSET( axel->conn[i].fd, fds ) )
+	if( FD_ISSET( axel->conn[i].tcp->fd, fds ) )
 	{
 		axel->conn[i].last_transfer = gettime();
-		size = read( axel->conn[i].fd, buffer, axel->conf->buffer_size );
+		size = tcp_read( axel->conn[i].tcp, buffer, axel->conf->buffer_size );
 		if( size == -1 )
 		{
 			if( axel->conf->verbose )

--- a/src/axel.h
+++ b/src/axel.h
@@ -52,6 +52,7 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <pthread.h>
+#include <openssl/ssl.h>
 
 /* Internationalization */
 #define PACKAGE			"axel"
@@ -80,6 +81,7 @@ typedef message_t if_t;
 #include "ftp.h"
 #include "http.h"
 #include "conn.h"
+#include "ssl.h"
 #include "search.h"
 
 #define min( a, b )		( (a) < (b) ? (a) : (b) )

--- a/src/conf.c
+++ b/src/conf.c
@@ -89,6 +89,7 @@ int conf_loadfile( conf_t *conf, char *file )
 		get_config_number( max_speed );
 		get_config_number( verbose );
 		get_config_number( alternate_output );
+		get_config_number( insecure );
 
 		get_config_number( search_timeout );
 		get_config_number( search_threads );
@@ -136,6 +137,7 @@ int conf_init( conf_t *conf )
 	conf->max_speed			= 0;
 	conf->verbose			= 1;
 	conf->alternate_output		= 0;
+	conf->insecure			= 0;
 
 	conf->search_timeout		= 10;
 	conf->search_threads		= 3;

--- a/src/conf.h
+++ b/src/conf.h
@@ -36,6 +36,7 @@ typedef struct
 	int max_speed;
 	int verbose;
 	int alternate_output;
+	int insecure;
 
 	if_t *interfaces;
 

--- a/src/conn.h
+++ b/src/conn.h
@@ -24,7 +24,19 @@
 #define PROTO_FTP	1
 #define PROTO_HTTP	2
 #define PROTO_HTTPS	3
-#define PROTO_DEFAULT	PROTO_FTP
+
+#define PROTO_DEFAULT		PROTO_FTP
+#define PROTO_DEFAULT_PORT	PROTO_FTP_PORT
+#define PROTO_DEFAULT_NAME	PROTO_FTP_NAME
+
+#define	PROTO_FTP_PORT		21
+#define	PROTO_FTP_NAME		"ftp"
+
+#define	PROTO_HTTP_PORT		80
+#define	PROTO_HTTP_NAME		"http"
+
+#define	PROTO_HTTPS_PORT	443
+#define	PROTO_HTTPS_NAME	"https"
 
 typedef struct
 {
@@ -45,7 +57,7 @@ typedef struct
 	long long int size;		/* File size, not 'connection size'.. */
 	long long int currentbyte;
 	long long int lastbyte;
-	int fd;
+	tcp_t *tcp;
 	int enabled;
 	int supported;
 	int last_transfer;

--- a/src/conn.h
+++ b/src/conn.h
@@ -21,22 +21,38 @@
 
 /* Connection stuff */
 
-#define PROTO_FTP	1
-#define PROTO_HTTP	2
-#define PROTO_HTTPS	3
+#define PROTO_SECURE_MASK	(1<<0)  /* bit 0 - 0 = insecure, 1 = secure */
+#define PROTO_PROTO_MASK	(1<<1)  /* bit 1 = 0 = ftp,      1 = http   */
 
-#define PROTO_DEFAULT		PROTO_FTP
-#define PROTO_DEFAULT_PORT	PROTO_FTP_PORT
-#define PROTO_DEFAULT_NAME	PROTO_FTP_NAME
+#define PROTO_INSECURE		(0<<0)
+#define PROTO_SECURE		(1<<0)
+#define PROTO_PROTO_FTP		(0<<1)
+#define PROTO_PROTO_HTTP	(1<<1)
 
+#define PROTO_IS_FTP(proto) \
+	(((proto) & PROTO_PROTO_MASK) == PROTO_PROTO_FTP)
+#define PROTO_IS_SECURE(proto) \
+	(((proto) & PROTO_SECURE_MASK) == PROTO_SECURE)
+
+#define PROTO_FTP		(PROTO_PROTO_FTP|PROTO_INSECURE)
 #define	PROTO_FTP_PORT		21
 #define	PROTO_FTP_NAME		"ftp"
 
+#define PROTO_FTPS		(PROTO_PROTO_FTP|PROTO_SECURE)
+#define	PROTO_FTPS_PORT		990
+#define	PROTO_FTPS_NAME		"ftps"
+
+#define PROTO_HTTP		(PROTO_PROTO_HTTP|PROTO_INSECURE)
 #define	PROTO_HTTP_PORT		80
 #define	PROTO_HTTP_NAME		"http"
 
+#define PROTO_HTTPS		(PROTO_PROTO_HTTP|PROTO_SECURE)
 #define	PROTO_HTTPS_PORT	443
 #define	PROTO_HTTPS_NAME	"https"
+
+#define PROTO_DEFAULT          PROTO_FTP
+#define PROTO_DEFAULT_PORT     PROTO_FTP_PORT
+#define PROTO_DEFAULT_NAME     PROTO_FTP_NAME
 
 typedef struct
 {

--- a/src/conn.h
+++ b/src/conn.h
@@ -23,6 +23,7 @@
 
 #define PROTO_FTP	1
 #define PROTO_HTTP	2
+#define PROTO_HTTPS	3
 #define PROTO_DEFAULT	PROTO_FTP
 
 typedef struct
@@ -32,6 +33,7 @@ typedef struct
 	int proto;
 	int port;
 	int proxy;
+	char *proto_name;
 	char host[MAX_STRING];
 	char dir[MAX_STRING];
 	char file[MAX_STRING];

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -23,12 +23,13 @@
 
 #include "axel.h"
 
-int ftp_connect( ftp_t *conn, char *host, int port, char *user, char *pass )
+int ftp_connect( ftp_t *conn, int proto, char *host, int port, char *user, char *pass )
 {
 	conn->data_tcp.fd = -1;
 	conn->message = malloc( MAX_STRING );
+	conn->proto = proto;
 
-	if( tcp_connect( &conn->tcp, host, port, 0,
+	if( tcp_connect( &conn->tcp, host, port, PROTO_IS_SECURE(conn->proto),
 		conn->local_if, conn->message ) == -1 )
 		return( 0 );
 
@@ -242,8 +243,9 @@ int ftp_data( ftp_t *conn )
 			sprintf( conn->message, _("Error opening passive data connection.\n") );
 			return( 0 );
 		}
-		if( tcp_connect( &conn->data_tcp, host,
-			info[4] * 256 + info[5], 0, conn->local_if, conn->message ) == -1 )
+		if( tcp_connect( &conn->data_tcp, host, info[4] * 256 + info[5],
+		    PROTO_IS_SECURE(conn->proto), conn->local_if,
+		    conn->message ) == -1 )
 			return( 0 );
 
 		return( 1 );

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -28,11 +28,9 @@ int ftp_connect( ftp_t *conn, char *host, int port, char *user, char *pass )
 	conn->data_tcp.fd = -1;
 	conn->message = malloc( MAX_STRING );
 
-	if( tcp_connect( &conn->tcp, host, port, 0, conn->local_if ) == -1 )
-	{
-		sprintf( conn->message, _("Unable to connect to server %s:%i\n"), host, port );
+	if( tcp_connect( &conn->tcp, host, port, 0,
+		conn->local_if, conn->message ) == -1 )
 		return( 0 );
-	}
 
 	if( ftp_wait( conn ) / 100 != 2 )
 		return( 0 );
@@ -245,11 +243,8 @@ int ftp_data( ftp_t *conn )
 			return( 0 );
 		}
 		if( tcp_connect( &conn->data_tcp, host,
-			info[4] * 256 + info[5], 0, conn->local_if ) == -1 )
-		{
-			sprintf( conn->message, _("Error opening passive data connection.\n") );
+			info[4] * 256 + info[5], 0, conn->local_if, conn->message ) == -1 )
 			return( 0 );
-		}
 
 		return( 1 );
 /*	}

--- a/src/ftp.c
+++ b/src/ftp.c
@@ -25,10 +25,10 @@
 
 int ftp_connect( ftp_t *conn, char *host, int port, char *user, char *pass )
 {
-	conn->data_fd = -1;
+	conn->data_tcp.fd = -1;
 	conn->message = malloc( MAX_STRING );
 
-	if( ( conn->fd = tcp_connect( host, port, conn->local_if ) ) == -1 )
+	if( tcp_connect( &conn->tcp, host, port, 0, conn->local_if ) == -1 )
 	{
 		sprintf( conn->message, _("Unable to connect to server %s:%i\n"), host, port );
 		return( 0 );
@@ -62,10 +62,8 @@ int ftp_connect( ftp_t *conn, char *host, int port, char *user, char *pass )
 
 void ftp_disconnect( ftp_t *conn )
 {
-	if( conn->fd > 0 )
-		close( conn->fd );
-	if( conn->data_fd > 0 )
-		close( conn->data_fd );
+	tcp_close( &conn->tcp );
+	tcp_close( &conn->data_tcp );
 	if( conn->message )
 	{
 		free( conn->message );
@@ -73,7 +71,6 @@ void ftp_disconnect( ftp_t *conn )
 	}
 
 	*conn->cwd = 0;
-	conn->fd = conn->data_fd = -1;
 }
 
 /* Change current working directory */
@@ -135,7 +132,7 @@ long long int ftp_size( ftp_t *conn, char *file, int maxredir )
 	memset( reply, 0, size );
 	*reply = '\n';
 	i = 1;
-	while( ( j = read( conn->data_fd, reply + i, size - i - 3 ) ) > 0 )
+	while( ( j = tcp_read( &conn->data_tcp, reply + i, size - i - 3 ) ) > 0 )
 	{
 		i += j;
 		reply[i] = 0;
@@ -146,8 +143,7 @@ long long int ftp_size( ftp_t *conn, char *file, int maxredir )
 			memset( reply + size / 2, 0, size / 2 );
 		}
 	}
-	close( conn->data_fd );
-	conn->data_fd = -1;
+	tcp_close( &conn->data_tcp );
 
 	if( ftp_wait( conn ) / 100 != 2 )
 	{
@@ -223,7 +219,7 @@ int ftp_data( ftp_t *conn )
 	char host[MAX_STRING];
 
 	/* Already done? */
-	if( conn->data_fd > 0 )
+	if( conn->data_tcp.fd > 0 )
 		return( 0 );
 
 /*	if( conn->ftp_mode == FTP_PASSIVE )
@@ -248,8 +244,8 @@ int ftp_data( ftp_t *conn )
 			sprintf( conn->message, _("Error opening passive data connection.\n") );
 			return( 0 );
 		}
-		if( ( conn->data_fd = tcp_connect( host,
-			info[4] * 256 + info[5], conn->local_if ) ) == -1 )
+		if( tcp_connect( &conn->data_tcp, host,
+			info[4] * 256 + info[5], 0, conn->local_if ) == -1 )
 		{
 			sprintf( conn->message, _("Error opening passive data connection.\n") );
 			return( 0 );
@@ -279,7 +275,7 @@ int ftp_command( ftp_t *conn, char *format, ... )
 	fprintf( stderr, "fd(%i)<--%s", conn->fd, cmd );
 #endif
 
-	if( write( conn->fd, cmd, strlen( cmd ) ) != strlen( cmd ) )
+	if( tcp_write( &conn->tcp, cmd, strlen( cmd ) ) != strlen( cmd ) )
 	{
 		sprintf( conn->message, _("Error writing command %s\n"), format );
 		return( 0 );
@@ -303,7 +299,7 @@ int ftp_wait( ftp_t *conn )
 	{
 		do
 		{
-			r += i = read( conn->fd, conn->message + r, 1 );
+			r += i = tcp_read( &conn->tcp, conn->message + r, 1 );
 			if( i <= 0 )
 			{
 				sprintf( conn->message, _("Connection gone.\n") );

--- a/src/ftp.h
+++ b/src/ftp.h
@@ -31,11 +31,12 @@ typedef struct
 	int status;
 	tcp_t tcp;
 	tcp_t data_tcp;
+	int proto;
 	int ftp_mode;
 	char *local_if;
 } ftp_t;
 
-int ftp_connect( ftp_t *conn, char *host, int port, char *user, char *pass );
+int ftp_connect( ftp_t *conn, int proto, char *host, int port, char *user, char *pass );
 void ftp_disconnect( ftp_t *conn );
 int ftp_wait( ftp_t *conn );
 int ftp_command( ftp_t *conn, char *format, ... );

--- a/src/http.c
+++ b/src/http.c
@@ -48,6 +48,7 @@ int http_connect( http_t *conn, int proto, char *proxy, char *host, int port, ch
 		}
 		host = tconn->host;
 		port = tconn->port;
+		proto = tconn->proto;
 		conn->proxy = 1;
 	}
 	else

--- a/src/http.c
+++ b/src/http.c
@@ -56,12 +56,9 @@ int http_connect( http_t *conn, int proto, char *proxy, char *host, int port, ch
 		conn->proxy = 0;
 	} }
 
-	if( tcp_connect( &conn->tcp, host, port, proto == PROTO_HTTPS, conn->local_if ) == -1 )
-	{
-		/* We'll put the message in conn->headers, not in request */
-		sprintf( conn->headers, _("Unable to connect to server %s:%i\n"), host, port );
+	if( tcp_connect( &conn->tcp, host, port, proto == PROTO_HTTPS,
+		conn->local_if, conn->headers ) == -1 )
 		return( 0 );
-	}
 
 	if( *user == 0 )
 	{
@@ -153,12 +150,12 @@ int http_exec( http_t *conn )
 
 	while ( nwrite < strlen( conn->request ) ) {
 		if( ( i = tcp_write( &conn->tcp, conn->request + nwrite, strlen( conn->request ) - nwrite ) ) < 0 ) {
-        		if (errno == EINTR || errno == EAGAIN) continue;
+	if (errno == EINTR || errno == EAGAIN) continue;
 			/* We'll put the message in conn->headers, not in request */
 			sprintf( conn->headers, _("Connection gone while writing.\n") );
 			return( 0 );
 		}
-    		nwrite += i;
+		nwrite += i;
 	}
 
 	*conn->headers = 0;

--- a/src/http.c
+++ b/src/http.c
@@ -34,6 +34,12 @@ int http_connect( http_t *conn, int proto, char *proxy, char *host, int port, ch
 	conn_t tconn[1];
 	int i;
 
+	if (proto == PROTO_HTTPS)
+	{
+		sprintf( conn->headers, _("Unsupported protocol https\n") );
+		return( 0 );
+	}
+
 	strncpy( conn->host, host, MAX_STRING );
 	conn->proto = proto;
 
@@ -96,8 +102,20 @@ void http_get( http_t *conn, char *lurl )
 	*conn->request = 0;
 	if( conn->proxy )
 	{
-		http_addheader( conn, "GET %s://%s%s HTTP/1.0",
-			conn->proto == PROTO_HTTP ? "http" : "ftp", conn->host, lurl );
+		const char* proto;
+		switch( conn->proto )
+		{
+			case PROTO_FTP:
+				proto = "ftp";
+				break;
+			case PROTO_HTTP:
+				proto = "http";
+				break;
+			case PROTO_HTTPS:
+				proto = "https";
+				break;
+		}
+		http_addheader( conn, "GET %s://%s%s HTTP/1.0", proto, conn->host, lurl );
 	}
 	else
 	{

--- a/src/http.c
+++ b/src/http.c
@@ -56,7 +56,7 @@ int http_connect( http_t *conn, int proto, char *proxy, char *host, int port, ch
 		conn->proxy = 0;
 	} }
 
-	if( tcp_connect( &conn->tcp, host, port, proto == PROTO_HTTPS,
+	if( tcp_connect( &conn->tcp, host, port, PROTO_IS_SECURE(proto),
 		conn->local_if, conn->headers ) == -1 )
 		return( 0 );
 
@@ -92,17 +92,20 @@ void http_get( http_t *conn, char *lurl )
 	*conn->request = 0;
 	if( conn->proxy )
 	{
-		const char* proto;
+		const char* proto = "";
 		switch( conn->proto )
 		{
 			case PROTO_FTP:
-				proto = "ftp";
+				proto = PROTO_FTP_NAME;
+				break;
+			case PROTO_FTPS:
+				proto = PROTO_FTPS_NAME;
 				break;
 			case PROTO_HTTP:
-				proto = "http";
+				proto = PROTO_HTTP_NAME;
 				break;
 			case PROTO_HTTPS:
-				proto = "https";
+				proto = PROTO_HTTPS_NAME;
 				break;
 		}
 		http_addheader( conn, "GET %s://%s%s HTTP/1.0", proto, conn->host, lurl );

--- a/src/http.h
+++ b/src/http.h
@@ -34,7 +34,7 @@ typedef struct
 	long long int firstbyte;
 	long long int lastbyte;
 	int status;
-	int fd;
+	tcp_t tcp;
 	char *local_if;
 } http_t;
 

--- a/src/search.c
+++ b/src/search.c
@@ -111,7 +111,7 @@ int search_makelist( search_t *results, char *url )
 		return( 1 );
 	}
 
-	while( ( i = read( conn->fd, s + j, size - j ) ) > 0 )
+	while( ( i = tcp_read( conn->tcp, s + j, size - j ) ) > 0 )
 	{
 		j += i;
 		if( j + 10 >= size )

--- a/src/search.c
+++ b/src/search.c
@@ -42,6 +42,7 @@ int main( int argc, char *argv[] )
 	}
 
 	conf_init( conf );
+	ssl_init( conf );
 
 	res = malloc( sizeof( search_t ) * ( conf->search_amount + 1 ) );
 	memset( res, 0, sizeof( search_t ) * ( conf->search_amount + 1 ) );

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -62,7 +62,7 @@ SSL* ssl_connect( int fd )
 
 	int err = SSL_connect( ssl );
 	if( err <= 0 ) {
-		fprintf(stderr, "SSL connection failed: %s\n", ERR_reason_error_string(ERR_get_error()));
+		fprintf(stderr, _("SSL connection failed: %s\n"), ERR_reason_error_string(ERR_get_error()));
 		return NULL;
 	}
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26,6 +26,8 @@
 
 #include "axel.h"
 
+#include <openssl/err.h>
+
 static SSL_CTX *ssl_ctx = NULL;
 
 void ssl_init( void )
@@ -37,6 +39,8 @@ void ssl_init( void )
 	SSL_load_error_strings();
 
 	ssl_ctx = SSL_CTX_new( SSLv23_client_method() );
+	SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
+	SSL_CTX_set_verify_depth(ssl_ctx, 0);
 }
 
 SSL* ssl_connect( int fd )
@@ -49,8 +53,8 @@ SSL* ssl_connect( int fd )
 	SSL_set_fd( ssl, fd );
 
 	int err = SSL_connect( ssl );
-	if (err <= 0) {
-		printf("SSL_connect: %d\n", SSL_get_error(ssl, err));
+	if( err <= 0 ) {
+		fprintf(stderr, "SSL connection failed: %s\n", ERR_reason_error_string(ERR_get_error()));
 		return NULL;
 	}
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29,8 +29,14 @@
 #include <openssl/err.h>
 
 static SSL_CTX *ssl_ctx = NULL;
+static conf_t *conf = NULL;
 
-void ssl_init( void )
+void ssl_init( conf_t *global_conf )
+{
+	conf = global_conf;
+}
+
+void ssl_startup( void )
 {
 	if( ssl_ctx != NULL )
 		return;
@@ -39,15 +45,17 @@ void ssl_init( void )
 	SSL_load_error_strings();
 
 	ssl_ctx = SSL_CTX_new( SSLv23_client_method() );
-	SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
-	SSL_CTX_set_verify_depth(ssl_ctx, 0);
+	if( !conf->insecure ) {
+		SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER, NULL);
+		SSL_CTX_set_verify_depth(ssl_ctx, 0);
+	}
 }
 
 SSL* ssl_connect( int fd )
 {
 	SSL* ssl;
 
-	ssl_init();
+	ssl_startup();
 
 	ssl = SSL_new( ssl_ctx );
 	SSL_set_fd( ssl, fd );

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -51,7 +51,7 @@ void ssl_startup( void )
 	}
 }
 
-SSL* ssl_connect( int fd )
+SSL* ssl_connect( int fd, char *message )
 {
 	SSL* ssl;
 
@@ -62,14 +62,14 @@ SSL* ssl_connect( int fd )
 
 	int err = SSL_connect( ssl );
 	if( err <= 0 ) {
-		fprintf(stderr, _("SSL connection failed: %s\n"), ERR_reason_error_string(ERR_get_error()));
+		sprintf(message, _("SSL error: %s\n"), ERR_reason_error_string(ERR_get_error()));
 		return NULL;
 	}
 
 	return ssl;
 }
 
-void ssl_disconnect( SSL* ssl )
+void ssl_disconnect( SSL *ssl )
 {
 	SSL_shutdown( ssl );
 	SSL_free( ssl );

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -24,5 +24,6 @@
 
 /* SSL interface */
 
+void ssl_init( conf_t *conf );
 SSL* ssl_connect( int fd );
 void ssl_disconnect( SSL* ssl );

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -25,5 +25,5 @@
 /* SSL interface */
 
 void ssl_init( conf_t *conf );
-SSL* ssl_connect( int fd );
-void ssl_disconnect( SSL* ssl );
+SSL* ssl_connect( int fd, char *message );
+void ssl_disconnect( SSL *ssl );

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -2,7 +2,10 @@
   Axel -- A lighter download accelerator for Linux and other Unices
 
   Copyright 2001-2007 Wilmer van der Gaast
-  Copyright 2008      Y Giridhar Appaji Nag
+  Copyright 2007-2009 Y Giridhar Appaji Nag
+  Copyright 2008-2009 Philipp Hagemeister
+  Copyright 2015-2016 Joao Eriberto Mota Filho
+  Copyright 2016      Ivan Gimenez
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License
@@ -19,26 +22,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-/* FTP control include file */
+/* SSL interface */
 
-#define FTP_PASSIVE	1
-#define FTP_PORT	2
-
-typedef struct
-{
-	char cwd[MAX_STRING];
-	char *message;
-	int status;
-	tcp_t tcp;
-	tcp_t data_tcp;
-	int ftp_mode;
-	char *local_if;
-} ftp_t;
-
-int ftp_connect( ftp_t *conn, char *host, int port, char *user, char *pass );
-void ftp_disconnect( ftp_t *conn );
-int ftp_wait( ftp_t *conn );
-int ftp_command( ftp_t *conn, char *format, ... );
-int ftp_cwd( ftp_t *conn, char *cwd );
-int ftp_data( ftp_t *conn );
-long long int ftp_size( ftp_t *conn, char *file, int maxredir );
+SSL* ssl_connect( int fd );
+void ssl_disconnect( SSL* ssl );

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -25,7 +25,7 @@ typedef struct {
 	SSL *ssl;
 } tcp_t;
 
-int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_if );
+int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_if, char *message );
 void tcp_close( tcp_t *tcp );
 
 int tcp_read( tcp_t *tcp, void *buffer, int size );

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -20,5 +20,15 @@
 
 /* TCP control include file */
 
-int tcp_connect( char *hostname, int port, char *local_if );
+typedef struct {
+	int fd;
+	SSL *ssl;
+} tcp_t;
+
+int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_if );
+void tcp_close( tcp_t *tcp );
+
+int tcp_read( tcp_t *tcp, void *buffer, int size );
+int tcp_write( tcp_t *tcp, void *buffer, int size );
+
 int get_if_ip( char *iface, char *ip );

--- a/src/text.c
+++ b/src/text.c
@@ -55,6 +55,7 @@ static struct option axel_options[] =
 	{ "help",		0,	NULL,	'h' },
 	{ "version",		0,	NULL,	'V' },
 	{ "alternate",		0,	NULL,	'a' },
+	{ "insecure", 		0,	NULL,	'k' },
 	{ "header",		1,	NULL,	'H' },
 	{ "user-agent",		1,	NULL,	'U' },
 	{ NULL,			0,	NULL,	0 }
@@ -92,7 +93,7 @@ int main( int argc, char *argv[] )
 	{
 		int option;
 
-		option = getopt_long( argc, argv, "s:n:o:S::NqvhVaH:U:", axel_options, NULL );
+		option = getopt_long( argc, argv, "s:n:o:S::NqvhVakH:U:", axel_options, NULL );
 		if( option == -1 )
 			break;
 
@@ -133,6 +134,9 @@ int main( int argc, char *argv[] )
 		case 'a':
 			conf->alternate_output = 1;
 			break;
+		case 'k':
+			conf->insecure = 1;
+			break;
 		case 'N':
 			*conf->http_proxy = 0;
 			break;
@@ -171,6 +175,7 @@ int main( int argc, char *argv[] )
 		print_help();
 		return( 1 );
 	}
+	ssl_init( conf );
 
 	if( argc - optind == 0 )
 	{
@@ -563,6 +568,7 @@ void print_help()
 		"-H x\tAdd header string\n"
 		"-U x\tSet user agent\n"
 		"-N\tJust don't use any proxy server\n"
+		"-k\tDon't verify the SSL certificate\n"
 		"-q\tLeave stdout alone\n"
 		"-v\tMore status information\n"
 		"-a\tAlternate progress indicator\n"
@@ -580,6 +586,7 @@ void print_help()
 		"--header=x\t\t-H x\tAdd header string\n"
 		"--user-agent=x\t\t-U x\tSet user agent\n"
 		"--no-proxy\t\t-N\tJust don't use any proxy server\n"
+		"--insecure\t\t-k\tDon't verify the SSL certificate\n"
 		"--quiet\t\t\t-q\tLeave stdout alone\n"
 		"--verbose\t\t-v\tMore status information\n"
 		"--alternate\t\t-a\tAlternate progress indicator\n"


### PR DESCRIPTION
Most of the work gets done in tcp.c

The raw socket handles in ftp.c, http.c and conn.c have been replaced by tcp_t structs, which have the handle and an optional SSL pointer, which is set for secure sockets.

Raw socket IO functions have been replaced by tcp_-prefixed equivalents that look at the tcp_t struct and use the ssl versions where appropriate.

Certificate validation is very basic. By default, axel will abort on invalid certificates. The -k / --insecure flag can be used to bypass this check.

Secure sockets are hardwired off in the ftp code at the moment. I'll take a look at adding ftps support soon.

