### PR TITLE
Fix rpl_malloc not found when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,7 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h libintl.h limits.h locale.h netdb.h netine
 AC_TYPE_SIZE_T
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([gettimeofday inet_ntoa memset select setlocale socket strcasecmp strchr strrchr strstr])
+AC_CHECK_FUNCS([malloc realloc gettimeofday inet_ntoa memset select setlocale socket strcasecmp strchr strrchr strstr])
 
 # Optional (but included-by-default) openssl support
 AC_ARG_WITH([openssl],


### PR DESCRIPTION
AC_FUNC_MALLOC & AC_FUNC_REALLOC cause link errors when cross-compiling.

It seems the preferred solution is to just remove them, and optionally adding
them to the AC_CHECK_FUNCS section.

eg.
    https://github.com/LLNL/ior/issues/4
    http://rickfoosusa.blogspot.com.au/2011/11/howto-fix-undefined-reference-to.html