### PR TITLE
Fix a build fail when using OpenSSL 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_ARG_WITH([openssl],
 
 AS_IF([test "x$with_openssl" != xno], [
     AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL])
-    AC_SEARCH_LIBS([SSL_library_init], [ssl], [], [
+    AC_SEARCH_LIBS([OPENSSL_init_ssl], [ssl], [], [
         AC_MSG_ERROR([libssl not found])
     ])
     AC_SEARCH_LIBS([ERR_get_error], [crypto], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_ARG_WITH([openssl],
 
 AS_IF([test "x$with_openssl" != xno], [
     AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL])
-    AC_SEARCH_LIBS([OPENSSL_init_ssl], [ssl], [], [
+    AC_SEARCH_LIBS([SSL_new], [ssl], [], [
         AC_MSG_ERROR([libssl not found])
     ])
     AC_SEARCH_LIBS([ERR_get_error], [crypto], [], [


### PR DESCRIPTION
Fix a FTBFS when using OpenSSL 1.1.0. For details, see 'HISTORY' here[1].

This fix will close the bug #829452 in Debian[2].

@sdt, can you check this change and commit? Thanks!

Eriberto

[1] https://www.openssl.org/docs/manmaster/ssl/SSL_library_init.html
[2] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829452