### PR TITLE
Extract file sizes from the Content-Range header

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -373,7 +373,15 @@ int conn_info( conn_t *conn )
 		}
 
 		conn->size = http_size( conn->http );
-		if( conn->http->status == 206 && conn->size >= 0 )
+		i = http_size_from_range( conn->http );
+		if( i > 0 && conn->size != i + 1 ) {
+			/* This means that the server has a bug. This version currently
+			   uses the larger of the reported sizes, but it would be an
+			   alternative to set supported = 0. */
+			conn->supported = 1;
+			conn->size = max(i, conn->size + 1);
+		}
+		else if( conn->http->status == 206 && conn->size >= 0 )
 		{
 			conn->supported = 1;
 			conn->size ++;

--- a/src/http.c
+++ b/src/http.c
@@ -245,6 +245,24 @@ long long int http_size( http_t *conn )
 	return( j );
 }
 
+long long int http_size_from_range( http_t *conn )
+{
+	char *i;
+	long long int j;
+
+	if( ( i = http_header( conn, "Content-Range:" ) ) == NULL )
+		return( -2 );
+
+	i = strchr(i, '/');
+	if( i == NULL )
+		return( -2 );
+
+	if( sscanf( i + 1, "%lld", &j ) != 1 )
+		return( -3 );
+
+	return( j );
+}
+
 void http_filename( http_t *conn, char *filename )
 {
 	char *h;

--- a/src/http.h
+++ b/src/http.h
@@ -62,5 +62,6 @@ int http_exec( http_t *conn );
 char *http_header( http_t *conn, char *header );
 void http_filename( http_t *conn, char *filename );
 long long int http_size( http_t *conn );
+long long int http_size_from_range( http_t *conn );
 void http_encode( char *s );
 void http_decode( char *s );


### PR DESCRIPTION
This is a possible solution for bug #33.

The commit extracts file sizes from the `Content-Range` header as well. If it is present and the file size given in the header differs from the file size given in the `Content-Length` header, then the larger of the two numbers is used as the file size.

If you'd prefer to in this case switch off partial downloading entirely, then this commit is still a good basis do to that. All that'd need to be changed is that in line 381, `supported` must be set to `0` instead of `1´.