### PR TITLE
For servers running on port, axel should set port properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/.deps
 src/axel
 src/Makefile.in
 stamp-h1
+*.po~

--- a/src/conn.c
+++ b/src/conn.c
@@ -276,7 +276,7 @@ int conn_setup( conn_t *conn )
 		snprintf( s, MAX_STRING, "%s%s", conn->dir, conn->file );
 		conn->http->firstbyte = conn->currentbyte;
 		conn->http->lastbyte = conn->lastbyte;
-		http_get( conn->http, s );
+		http_get( conn->http, conn->port, s );
 		http_addheader( conn->http, "User-Agent: %s", conn->conf->user_agent );
 		for( i = 0; i < conn->conf->add_header_count; i++)
 			http_addheader( conn->http, "%s", conn->conf->add_header[i] );

--- a/src/http.c
+++ b/src/http.c
@@ -134,7 +134,7 @@ void http_get( http_t *conn, int port, char *lurl )
                   Set port as part of Host header only if it is available and valid.
                   - https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
                 */
-                if ( port > 0 ) {
+                if ( port > 0 && port != 443 && port != 80 ) {
                         http_addheader( conn, "Host: %s:%d", conn->host, port );
                 } else {
                         http_addheader( conn, "Host: %s", conn->host, port );

--- a/src/http.c
+++ b/src/http.c
@@ -104,7 +104,7 @@ void http_disconnect( http_t *conn )
 	tcp_close( &conn->tcp );
 }
 
-void http_get( http_t *conn, char *lurl )
+void http_get( http_t *conn, int port, char *lurl )
 {
 	*conn->request = 0;
 	if( conn->proxy )
@@ -130,7 +130,15 @@ void http_get( http_t *conn, char *lurl )
 	else
 	{
 		http_addheader( conn, "GET %s HTTP/1.0", lurl );
-		http_addheader( conn, "Host: %s", conn->host );
+                /*
+                  Set port as part of Host header only if it is available and valid.
+                  - https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
+                */
+                if ( port > 0 ) {
+                        http_addheader( conn, "Host: %s:%d", conn->host, port );
+                } else {
+                        http_addheader( conn, "Host: %s", conn->host, port );
+                }
 	}
 	if( *conn->auth )
 		http_addheader( conn, "Authorization: Basic %s", conn->auth );

--- a/src/http.h
+++ b/src/http.h
@@ -57,7 +57,7 @@ typedef struct
 
 int http_connect( http_t *conn, int proto, char *proxy, char *host, int port, char *user, char *pass );
 void http_disconnect( http_t *conn );
-void http_get( http_t *conn, char *lurl );
+void http_get( http_t *conn, int port, char *lurl );
 void http_addheader( http_t *conn, char *format, ... );
 int http_exec( http_t *conn );
 char *http_header( http_t *conn, char *header );


### PR DESCRIPTION
Host header should have a port set properly in accordance
with HTTP RFC2616.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23