### PR TITLE
Cleanup | Adding header guards

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -38,6 +38,9 @@
 
 /* Main include file */
 
+#ifndef __AXEL_H__
+#define __AXEL_H__
+
 #include "config.h"
 
 #include <time.h>
@@ -125,3 +128,5 @@ void axel_do( axel_t *axel );
 void axel_close( axel_t *axel );
 
 double gettime();
+
+#endif

--- a/src/conf.h
+++ b/src/conf.h
@@ -37,6 +37,9 @@
 
 /* Configuration handling include file */
 
+#ifndef __CONF_H__
+#define __CONF_H__
+
 typedef struct
 {
 	char default_filename[MAX_STRING];
@@ -68,3 +71,5 @@ typedef struct
 
 int conf_loadfile( conf_t *conf, char *file );
 int conf_init( conf_t *conf );
+
+#endif //__CONF_H__

--- a/src/conn.h
+++ b/src/conn.h
@@ -37,6 +37,9 @@
 
 /* Connection stuff */
 
+#ifndef __CONN_H__
+#define __CONN_H__
+
 #define PROTO_SECURE_MASK	(1<<0)  /* bit 0 - 0 = insecure, 1 = secure */
 #define PROTO_PROTO_MASK	(1<<1)  /* bit 1 = 0 = ftp,      1 = http   */
 
@@ -108,3 +111,6 @@ int conn_init( conn_t *conn );
 int conn_setup( conn_t *conn );
 int conn_exec( conn_t *conn );
 int conn_info( conn_t *conn );
+
+
+#endif //__CONN_H__

--- a/src/ftp.h
+++ b/src/ftp.h
@@ -36,6 +36,9 @@
 
 /* FTP control include file */
 
+#ifndef __FTP_H__
+#define __FTP_H__
+
 #define FTP_PASSIVE	1
 #define FTP_PORT	2
 
@@ -58,3 +61,5 @@ int ftp_command( ftp_t *conn, char *format, ... );
 int ftp_cwd( ftp_t *conn, char *cwd );
 int ftp_data( ftp_t *conn );
 long long int ftp_size( ftp_t *conn, char *file, int maxredir );
+
+#endif //__FTP_H__

--- a/src/http.h
+++ b/src/http.h
@@ -38,6 +38,9 @@
 
 /* HTTP control include file */
 
+#ifndef __HTTP_H__
+#define __HTTP_H__
+
 #define MAX_QUERY	2048		/* Should not grow larger.. */
 
 typedef struct
@@ -66,3 +69,5 @@ long long int http_size( http_t *conn );
 long long int http_size_from_range( http_t *conn );
 void http_encode( char *s );
 void http_decode( char *s );
+
+#endif

--- a/src/search.h
+++ b/src/search.h
@@ -34,6 +34,9 @@
 
 /* filesearching.com searcher include file */
 
+#ifndef __SEARCH_H__
+#define __SEARCH_H__
+
 typedef struct
 {
 	char url[MAX_STRING];
@@ -46,3 +49,5 @@ typedef struct
 int search_makelist( search_t *results, char *url );
 int search_getspeeds( search_t *results, int count );
 void search_sortlist( search_t *results, int count );
+
+#endif //__SEARCH_H__

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -34,6 +34,9 @@
 
 /* SSL interface */
 
+#ifndef __SSL_H__
+#define __SSL_H__
+
 #ifdef HAVE_OPENSSL
 
 void ssl_init( conf_t *conf );
@@ -41,3 +44,5 @@ SSL* ssl_connect( int fd, char *message );
 void ssl_disconnect( SSL *ssl );
 
 #endif /* HAVE_OPENSSL */
+
+#endif //__SSL_H__

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -35,6 +35,9 @@
 
 /* TCP control include file */
 
+#ifndef __TCP_H__
+#define __TCP_H__
+
 typedef struct {
 	int fd;
 	SSL *ssl;
@@ -47,3 +50,5 @@ int tcp_read( tcp_t *tcp, void *buffer, int size );
 int tcp_write( tcp_t *tcp, void *buffer, int size );
 
 int get_if_ip( char *iface, char *ip );
+
+#endif //__TCP_H__


### PR DESCRIPTION
Adding header guards in axel's header files to avoid potential duplicate includes.
