### PR TITLE
Fix '--with-openssl' flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_CHECK_FUNCS([malloc realloc gettimeofday inet_ntoa memset select setlocale so
 
 # Optional (but included-by-default) openssl support
 AC_ARG_WITH([openssl],
-    AC_HELP_STRING([--without-openssl],[disable TLS support]), [with_openssl=no], [with_openssl=yes])
+    AC_HELP_STRING([--without-openssl],[disable TLS support]), [], [with_openssl=yes])
 
 AS_IF([test "x$with_openssl" != xno], [
     AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL])


### PR DESCRIPTION
This one fixes configure flag to enable building with TLS support when it's forcefully requested. There are two options here:

- use `[]` as per [example in the doc](https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/External-Software.html)
- use `[with_openssl=${withval}]`, so the value is passed correctly later on

I decided to go with the first option since I find it shorter and more elegant. It should work for both `--with-openssl` and `--with-openssl=yes`.