### PR TITLE
Use of the keyword "extern"

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -118,10 +118,10 @@ typedef struct
 	url_t *url;
 } axel_t;
 
-axel_t *axel_new( conf_t *conf, int count, void *url );
-int axel_open( axel_t *axel );
-void axel_start( axel_t *axel );
-void axel_do( axel_t *axel );
-void axel_close( axel_t *axel );
+extern axel_t *axel_new( conf_t *conf, int count, void *url );
+extern int axel_open( axel_t *axel );
+extern void axel_start( axel_t *axel );
+extern void axel_do( axel_t *axel );
+extern void axel_close( axel_t *axel );
 
-double gettime();
+extern double gettime();


### PR DESCRIPTION
It will prevent the compiler to understand that it is an function definition (not prototype)
Tell to compiler that it is an prototype of a function implemented on another file