### PR TITLE
enhance max number of redirections

### DIFF
--- a/man/axel.1
+++ b/man/axel.1
@@ -42,6 +42,11 @@ bandwidth.
 Specify an alternative number of connections.
 .TP
 .B
+\fB--max-redirect\fP=x
+Specify an alternative number of redirections to follow when connecting to the
+server (default is 20).
+.TP
+.B
 \fB--output\fP=x, \fB-o\fP x
 Downloaded data will be put in a local file with the same name, unless you specify
 a different name using this option. You can specify a directory as well, the program

--- a/man/axel.txt
+++ b/man/axel.txt
@@ -30,6 +30,9 @@ OPTIONS
 
  --num-connections=x, -n x  Specify an alternative number of connections.
 
+ --max-redirect=x  Specify an alternative number of redirections to follow when connecting to the
+                   server (default is 20).
+
  --output=x, -o x  Downloaded data will be put in a local file with the same name, unless you specify
                    a different name using this option. You can specify a directory as well, the program
                    will append the filename.

--- a/src/axel.h
+++ b/src/axel.h
@@ -83,7 +83,7 @@
 /* Compiled-in settings */
 #define MAX_STRING		1024
 #define MAX_ADD_HEADERS	10
-#define MAX_REDIR		5
+#define MAX_REDIR		20
 #define AXEL_VERSION_STRING	"2.13.1"
 #define DEFAULT_USER_AGENT	"Axel " AXEL_VERSION_STRING " (" ARCH ")"
 

--- a/src/axel.h
+++ b/src/axel.h
@@ -83,7 +83,7 @@
 /* Compiled-in settings */
 #define MAX_STRING		1024
 #define MAX_ADD_HEADERS	10
-#define MAX_REDIR		20
+#define MAX_REDIRECT		20
 #define AXEL_VERSION_STRING	"2.13.1"
 #define DEFAULT_USER_AGENT	"Axel " AXEL_VERSION_STRING " (" ARCH ")"
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -106,6 +106,7 @@ int conf_loadfile( conf_t *conf, char *file )
 		get_config_number( connection_timeout );
 		get_config_number( reconnect_delay );
 		get_config_number( num_connections );
+		get_config_number( max_redirect );
 		get_config_number( buffer_size );
 		get_config_number( max_speed );
 		get_config_number( verbose );
@@ -155,6 +156,7 @@ int conf_init( conf_t *conf )
 	conf->connection_timeout	= 45;
 	conf->reconnect_delay		= 20;
 	conf->num_connections		= 4;
+	conf->max_redirect		= MAX_REDIRECT;
 	conf->buffer_size		= 5120;
 	conf->max_speed			= 0;
 	conf->verbose			= 1;

--- a/src/conf.h
+++ b/src/conf.h
@@ -50,6 +50,7 @@ typedef struct
 	int connection_timeout;
 	int reconnect_delay;
 	int num_connections;
+	int max_redirect;
 	int buffer_size;
 	int max_speed;
 	int verbose;

--- a/src/conn.c
+++ b/src/conn.c
@@ -335,7 +335,7 @@ int conn_info( conn_t *conn )
 
 		if( !ftp_cwd( conn->ftp, conn->dir ) )
 			return( 0 );
-		conn->size = ftp_size( conn->ftp, conn->file, MAX_REDIR );
+		conn->size = ftp_size( conn->ftp, conn->file, conn->conf->max_redirect );
 		if( conn->size < 0 )
 			conn->supported = 0;
 		if( conn->size == -1 )
@@ -389,9 +389,9 @@ int conn_info( conn_t *conn )
 
 			i ++;
 		}
-		while( conn->http->status / 100 == 3 && i < MAX_REDIR );
+		while( conn->http->status / 100 == 3 && i < conn->conf->max_redirect );
 
-		if( i == MAX_REDIR )
+		if( i == conn->conf->max_redirect )
 		{
 			sprintf( conn->message, _("Too many redirects.\n") );
 			return( 0 );

--- a/src/text.c
+++ b/src/text.c
@@ -54,6 +54,8 @@ static int get_term_width();
 
 int run = 1;
 
+#define MAX_REDIR_OPT	256
+
 #ifdef NOGETOPTLONG
 #define getopt_long( a, b, c, d, e ) getopt( a, b, c )
 #else
@@ -62,6 +64,7 @@ static struct option axel_options[] =
 	/* name			has_arg	flag	val */
 	{ "max-speed",		1,	NULL,	's' },
 	{ "num-connections",	1,	NULL,	'n' },
+	{ "max-redirect",	1,	NULL,   MAX_REDIR_OPT },
 	{ "output",		1,	NULL,	'o' },
 	{ "search",		2,	NULL,	'S' },
 	{ "no-proxy",		0,	NULL,	'N' },
@@ -134,6 +137,13 @@ int main( int argc, char *argv[] )
 				goto free_conf;
 			}
 			break;
+		case MAX_REDIR_OPT:
+			if( !sscanf( optarg, "%i", &conf->max_redirect ) )
+			{
+				print_help();
+				return( 1 );
+			}
+			break;
 		case 'o':
 			strncpy( fn, optarg, sizeof( fn ) );
 			break;
@@ -195,6 +205,12 @@ int main( int argc, char *argv[] )
 	{
 		print_help();
 		goto free_conf;
+	}
+
+	if ( conf->max_redirect < 0)
+	{
+		print_help();
+		return( 1 );
 	}
 
 #ifdef HAVE_OPENSSL
@@ -605,6 +621,7 @@ void print_help()
 		"\n"
 		"--max-speed=x\t\t-s x\tSpecify maximum speed (bytes per second)\n"
 		"--num-connections=x\t-n x\tSpecify maximum number of connections\n"
+		"--max-redirect=x\tSpecify maximum number of redirections\n"
 		"--output=f\t\t-o f\tSpecify local output file\n"
 		"--search[=x]\t\t-S [x]\tSearch for mirrors and download from x servers\n"
 		"--header=x\t\t-H x\tAdd header string\n"


### PR DESCRIPTION
I find annoying that sometimes portage (package manager on Gentoo) fails to download a package because the number of redirects allowed by axel is too small.
In those cases I have to fallback to wget and download the package manually.
With these small patches axel's behaviour becomes equal to wget:

1. set max redirects to 20 by default
2. allow max redirects to be tuned from command line