### PR TITLE
fix race segfault upon connection to HTTPS server

### DIFF
--- a/src/axel.h
+++ b/src/axel.h
@@ -60,6 +60,7 @@
 #include <signal.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
This pull request fixes issue #54 

==============================================

Since some time, axel would nondeterministically crash
when connecting to an HTTPS server.

On linux the crash was reasonably easy to reproduce
using the throttling, i.e. by launching the following command:

axel --num-connections=5 --max-speed=100000 https://url

It is not clear if something changed at some point in OpenSSL
thus making this bug more probable.

The issue seems to be that during SSL_connect() an object
in the SSL object, namely verify_store, that is borrowed
by the SSL_CTX object, is eventually free'd.

Being the verify_store borrowed by the SSL_CLX object, it
is shared among all the axel threads doing a SSL_connect()
each and thus triggering double frees.

Fix this issue by creating an SSL_CTX object per SSL one, thus
avoiding the race condition.

Signed-off-by: Antonio Quartulli <a@unstable.cc>