### PR TITLE
use proper max value for size

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -157,7 +157,7 @@ axel_t *axel_new( conf_t *conf, int count, const void *url )
 	}
 	s = conn_url( axel->conn );
 	strncpy( axel->url->text, s, MAX_STRING );
-	if( ( axel->size = axel->conn[0].size ) != INT_MAX )
+	if( ( axel->size = axel->conn[0].size ) != LLONG_MAX )
 	{
 		if( axel->conf->verbose > 0 )
 			axel_message( axel, _("File size: %lld bytes"), axel->size );
@@ -434,7 +434,7 @@ void axel_do( axel_t *axel )
 			if( axel->conf->verbose )
 			{
 				/* Only abnormal behaviour if: */
-				if( axel->conn[i].currentbyte < axel->conn[i].lastbyte && axel->size != INT_MAX )
+				if( axel->conn[i].currentbyte < axel->conn[i].lastbyte && axel->size != LLONG_MAX )
 				{
 					axel_message( axel, _("Connection %i unexpectedly closed"), i );
 				}

--- a/src/conn.c
+++ b/src/conn.c
@@ -339,7 +339,7 @@ int conn_info( conn_t *conn )
 		if( conn->size == -1 )
 			return( 0 );
 		else if( conn->size == -2 )
-			conn->size = INT_MAX;
+			conn->size = LLONG_MAX;
 	}
 	else
 	{
@@ -404,7 +404,7 @@ int conn_info( conn_t *conn )
 		else if( conn->http->status == 200 || conn->http->status == 206 )
 		{
 			conn->supported = 0;
-			conn->size = INT_MAX;
+			conn->size = LLONG_MAX;
 		}
 		else
 		{


### PR DESCRIPTION
axel->size is of type long long, therefore LLONG_MAX
should be used as max/err value instead of INT_MAX.

Signed-off-by: Antonio Quartulli <a@unstable.cc>