### PR TITLE
fix use-after-free of axel->conn member

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -572,8 +572,6 @@ void axel_close( axel_t *axel )
 				pthread_cancel( *axel->conn[i].setup_thread );
 			conn_disconnect( &axel->conn[i] );
 		}
-
-		free( axel->conn );
 	}
 
 	free( axel->url );
@@ -593,6 +591,7 @@ void axel_close( axel_t *axel )
 	print_messages( axel );
 
 	close( axel->outfd );
+	free( axel->conn );
 	free( axel );
 }
 


### PR DESCRIPTION
fix a use-after-free that might actually be linked to #50 . Although what I saw here happens only when killing the download and not before.

==============

When stopping the download, axel->conn should not
be free'd before having invoked save_state() as it
will be accessed once again to retrieve the current
state.

This use-after-free is easy reproducible on linux when
running axel with at least 10 connections. Probably, due to
some optimization, a smaller number of connections does not
trigger an immediate deallocation of the used heap and
therefore does not exhibit the bug.

Fix this issue by moving the free(axel->conn) instruction
to the end of the cleanup function.

Signed-off-by: Antonio Quartulli <a@unstable.cc>