### PR TITLE
add basic travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+sudo: required
+dist: trusty
+
+os: linux
+
+language: c
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+    - os: linux
+      compiler: clang
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+
+addons:
+  apt:
+    packages:
+      - linux-libc-dev
+      - autopoint
+      - libssl-dev
+      - clang
+
+cache:
+  ccache: true
+
+before_install:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update ; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew install gettext openssl; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew link --force gettext openssl; fi
+
+script:
+    - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+        export OSX_FLAGS="-I/usr/local/opt/openssl/include";
+      fi
+    - ./autogen.sh && ./configure CFLAGS="-O3 $OSX_FLAGS" && make


### PR DESCRIPTION
add basic support to build axel on linux (gcc & clang) and on osx.
I can't configure travis-ci myself because I am not owner/collaborator on the main repo, therefore it does not appear in my travis-ci panel.

Signed-off-by: Antonio Quartulli <a@unstable.cc>