### PR TITLE
Add port to Host HTTP header when different from service default

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -52,6 +52,7 @@ int http_connect( http_t *conn, int proto, char *proxy, char *host, int port, ch
 	conn_t tconn[1];
 
 	strncpy( conn->host, host, MAX_STRING );
+	conn->port = port;
 	conn->proto = proto;
 
 	if( proxy != NULL ) { if( *proxy != 0 )
@@ -116,7 +117,11 @@ void http_get( http_t *conn, char *lurl )
 	else
 	{
 		http_addheader( conn, "GET %s HTTP/1.0", lurl );
-		http_addheader( conn, "Host: %s", conn->host );
+		if ( ( conn->proto == PROTO_HTTP && conn->port != PROTO_HTTP_PORT ) ||
+		     ( conn->proto == PROTO_HTTPS && conn->port != PROTO_HTTPS_PORT ) )
+			http_addheader( conn, "Host: %s:%i", conn->host, conn->port );
+		else
+			http_addheader( conn, "Host: %s", conn->host );
 	}
 	if( *conn->auth )
 		http_addheader( conn, "Authorization: Basic %s", conn->auth );

--- a/src/http.h
+++ b/src/http.h
@@ -49,6 +49,7 @@ typedef struct
 	char auth[MAX_STRING];
 	char request[MAX_QUERY];
 	char headers[MAX_QUERY];
+	int port;
 	int proto;			/* FTP through HTTP proxies */
 	int proxy;
 	long long int firstbyte;


### PR DESCRIPTION
Improves PR #43 .
I wanted to add a Reported-by, but I don't know the name and the email of the reporter.

==============================

When the port being used during a HTTP connection is
different from the service default (80 or 443), the Host:
HTTP header should also contain the actual port being used,
as specified by RFC2616 section 14.23.

Signed-off-by: Antonio Quartulli <a@unstable.cc>