### PR TITLE
Add description for max_redirect to axelrc.example

### DIFF
--- a/doc/axelrc.example
+++ b/doc/axelrc.example
@@ -21,6 +21,11 @@
 #
 # num_connections = 4
 
+# Set the maximum number of redirects that Axel is allowed to follow. The
+# default value is 20.
+#
+# max_redirect = 20
+
 # If no data comes from a connection for this number of seconds, abort (and
 # resume) the connection.
 #


### PR DESCRIPTION
I hadn't realized that axel ships a axelrc.example file too.