### PR TITLE
Compile with -Werror by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ arch=$(uname -s)
 AC_DEFINE_UNQUOTED([ARCH], ["$arch"], ["Define architecture"])
 
 # Flags
-CFLAGS="$CFLAGS -Wall"
+CFLAGS="$CFLAGS -Wall -Werror"
 
 case "$arch" in
 FreeBSD | OpenBSD | NetBSD | Darwin )


### PR DESCRIPTION
Now that all the warnings are gone, it is recommended
to build with -Werror so that any newly introduced one
will prevent the developer from compiling Axel.

This will hopefully prevent the introduction of new warnings
in our code base.

Consequently, travis-ci will also fail if a new warning is
detected.

Signed-off-by: Antonio Quartulli <a@unstable.cc>