### PR TITLE
Fix crash in alternate output

### DIFF
--- a/src/axel.c
+++ b/src/axel.c
@@ -70,7 +70,7 @@ axel_t *axel_new( conf_t *conf, int count, const void *url )
 		goto nomem;
 
 	memset( axel, 0, sizeof( axel_t ) );
-	*axel->conf = *conf;
+	axel->conf = conf;
 	axel->conn = malloc( sizeof( conn_t ) * axel->conf->num_connections );
 	if( !axel->conn )
 		goto nomem;

--- a/src/axel.h
+++ b/src/axel.h
@@ -110,7 +110,7 @@ typedef message_t if_t;
 typedef struct
 {
 	conn_t *conn;
-	conf_t conf[1];
+	conf_t *conf;
 	char filename[MAX_STRING];
 	double start_time;
 	int next_state, finish_time;

--- a/src/text.c
+++ b/src/text.c
@@ -545,9 +545,19 @@ static void print_alternate_output(axel_t *axel)
 	long long int done=axel->bytes_done;
 	long long int total=axel->size;
 	double now = gettime();
-	int width = get_term_width() - 30;
-	char progress[width+1];
+	int width = get_term_width();
+	char *progress;
 
+	if( width < 40 )
+	{
+		fprintf( stderr, _("Can't setup alternate output. Deactivating.\n" ) );
+		axel->conf->alternate_output = 0;
+
+		return;
+	}
+
+	width -= 30;
+	progress = malloc(width);
 	memset(progress, '.', width);
 
 	for(int i=0;i<axel->conf->num_connections;i++)
@@ -592,6 +602,8 @@ static void print_alternate_output(axel_t *axel)
 	}
 
 	fflush( stdout );
+
+	free( progress );
 }
 
 static int get_term_width()


### PR DESCRIPTION
Avoid crash in alternate output, when axel can't get the terminal window spec.