### PR TITLE
Implement HTTP authentication support

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -52,6 +52,7 @@ typedef struct
 	int port;
 	int proto;			/* FTP through HTTP proxies */
 	int proxy;
+	char proxy_auth[MAX_STRING];
 	long long int firstbyte;
 	long long int lastbyte;
 	int status;


### PR DESCRIPTION
This is the patch taken from https://lists.alioth.debian.org/pipermail/axel-devel/2011-February/000198.html reformatted and cleaned up a bit. Unfortunately my test proxy (privoxy) does not support HTTP auth and therefore I couldn't this this.

Solves: #84 

===========================

A proxy server might require HTTP authentication too.
Ass support for such feature via HTTP header.

Signed-off-by: Tirtha Chatterjee <tirtha.p.chatterjee@gmail.com>
Signed-off-by: Antonio Quartulli <a@unstable.cc>