### PR TITLE
Allow user to choose between IPv4 and IPv6

### DIFF
--- a/doc/axelrc.example
+++ b/doc/axelrc.example
@@ -34,6 +34,14 @@
 # Set proxies. no_proxy is a comma-separated list of domains which are
 # local, axel won't use any proxy for them. You don't have to specify full
 # hostnames there.
+
+# Choose the IP protocol to use among IPv4 and IPv6. When a protocol is
+# chosen, no connection attempt will be performed with the other. Possible
+# value are "ipv4" or "ipv6". By default anyone will be used based on
+# the address returned by the resolv library.
+#
+# use_protocol= ipv4
+
 #
 # Note: If the HTTP_PROXY environment variable is set correctly already,
 # you don't have to set it again here. The setting should be in the same

--- a/man/axel.1
+++ b/man/axel.1
@@ -61,6 +61,14 @@ time-consuming because the program tests every server's speed, and it checks
 whether the file's still available.
 .TP
 .B
+\fB--ipv6\fP, \fB-6\fP
+Use the IPv6 protocol only when connecting to the host.
+.TP
+.B
+\fB--ipv4\fP, \fB-4\fP
+Use the IPv4 protocol only when connecting to the host.
+.TP
+.B
 \fB--no-proxy\fP, \fB-N\fP
 Do not use any proxy server to download the file. Not possible when a transparent proxy
 is active somewhere, of course.

--- a/man/axel.txt
+++ b/man/axel.txt
@@ -43,6 +43,10 @@ OPTIONS
                       time-consuming because the program tests every server's speed, and it checks
                       whether the file's still available.
 
+ --ipv6, -6  Use the IPv6 protocol only when connecting to the host.
+
+ --ipv4, -4  Use the IPv4 protocol only when connecting to the host.
+
  --no-proxy, -N  Do not use any proxy server to download the file. Not possible when a transparent proxy
                  is active somewhere, of course.
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -68,6 +68,21 @@ static int axel_fscanf( FILE *fp, const char *format, ...)
 	return( ret );
 }
 
+static int parse_protocol( conf_t *conf, const char *value )
+{
+	if( strcasecmp( value, "ipv4" ) == 0 )
+		conf->ai_family = AF_INET;
+	else if( strcasecmp( value, "ipv6" ) == 0 )
+		conf->ai_family = AF_INET6;
+	else
+	{
+		fprintf( stderr, _( "Unknown protocol %s\n" ), value );
+		return( 0 );
+	}
+
+	return( 1 );
+}
+
 int conf_loadfile( conf_t *conf, char *file )
 {
 	int line = 0, ret = 1;
@@ -150,6 +165,11 @@ int conf_loadfile( conf_t *conf, char *file )
 			if( parse_interfaces( conf, value ) )
 				continue;
 		}
+		else if( strcmp( key, "use_protocol" ) == 0 )
+		{
+			if( parse_protocol( conf, value ) )
+				continue;
+		}
 
 #if 0
 		/* FIXME broken code */
@@ -194,6 +214,9 @@ int conf_init( conf_t *conf )
 	conf->search_amount		= 15;
 	conf->search_top		= 3;
 	conf->add_header_count		= 0;
+
+	conf->ai_family			= AF_UNSPEC;
+
 	strncpy( conf->user_agent, DEFAULT_USER_AGENT, MAX_STRING );
 
 	conf->interfaces = malloc( sizeof( if_t ) );

--- a/src/conf.h
+++ b/src/conf.h
@@ -59,6 +59,8 @@ typedef struct
 
 	if_t *interfaces;
 
+	sa_family_t ai_family;
+
 	int search_timeout;
 	int search_threads;
 	int search_amount;

--- a/src/conn.c
+++ b/src/conn.c
@@ -234,6 +234,7 @@ int conn_init( conn_t *conn )
 	{
 		conn->ftp->local_if = conn->local_if;
 		conn->ftp->ftp_mode = FTP_PASSIVE;
+		conn->ftp->tcp.ai_family = conn->conf->ai_family;
 		if( !ftp_connect( conn->ftp, conn->proto, conn->host, conn->port, conn->user, conn->pass ) )
 		{
 			conn->message = conn->ftp->message;
@@ -250,6 +251,7 @@ int conn_init( conn_t *conn )
 	else
 	{
 		conn->http->local_if = conn->local_if;
+		conn->http->tcp.ai_family = conn->conf->ai_family;
 		if( !http_connect( conn->http, conn->proto, proxy, conn->host, conn->port, conn->user, conn->pass ) )
 		{
 			conn->message = conn->http->headers;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -56,7 +56,7 @@ int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_i
 	int sock_fd = -1;
 
 
-	if (local_if && *local_if) {
+	if (tcp->ai_family == AF_INET && local_if && *local_if) {
 		local_addr.sin_family = AF_INET;
 		local_addr.sin_port = 0;
 		local_addr.sin_addr.s_addr = inet_addr(local_if);
@@ -65,7 +65,7 @@ int tcp_connect( tcp_t *tcp, char *hostname, int port, int secure, char *local_i
 	snprintf(portstr, portstr_len, "%d", port);
 
 	memset(&ai_hints, 0, sizeof(ai_hints));
-	ai_hints.ai_family = AF_UNSPEC;
+	ai_hints.ai_family = tcp->ai_family;
 	ai_hints.ai_socktype = SOCK_STREAM;
 	ai_hints.ai_flags = AI_ADDRCONFIG;
 	ai_hints.ai_protocol = 0;

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -40,6 +40,7 @@
 
 typedef struct {
 	int fd;
+	sa_family_t ai_family;
 	SSL *ssl;
 } tcp_t;
 

--- a/src/text.c
+++ b/src/text.c
@@ -67,6 +67,8 @@ static struct option axel_options[] =
 	{ "max-redirect",	1,	NULL,   MAX_REDIR_OPT },
 	{ "output",		1,	NULL,	'o' },
 	{ "search",		2,	NULL,	'S' },
+	{ "ipv4",		0,	NULL,	'4' },
+	{ "ipv6",		0,	NULL,	'6' },
 	{ "no-proxy",		0,	NULL,	'N' },
 	{ "quiet",		0,	NULL,	'q' },
 	{ "verbose",		0,	NULL,	'v' },
@@ -111,7 +113,7 @@ int main( int argc, char *argv[] )
 	{
 		int option;
 
-		option = getopt_long( argc, argv, "s:n:o:S::NqvhVakH:U:", axel_options, NULL );
+		option = getopt_long( argc, argv, "s:n:o:S::46NqvhVakH:U:", axel_options, NULL );
 		if( option == -1 )
 			break;
 
@@ -155,6 +157,12 @@ int main( int argc, char *argv[] )
 				print_help();
 				goto free_conf;
 			}
+			break;
+		case '6':
+			conf->ai_family = AF_INET6;
+			break;
+		case '4':
+			conf->ai_family = AF_INET;
 			break;
 		case 'a':
 			conf->alternate_output = 1;
@@ -623,6 +631,8 @@ void print_help()
 		"-n x\tSpecify maximum number of connections\n"
 		"-o f\tSpecify local output file\n"
 		"-S [x]\tSearch for mirrors and download from x servers\n"
+		"-4\tConnect using IPv4\n"
+		"-6\tConnect using IPv6\n"
 		"-H x\tAdd header string\n"
 		"-U x\tSet user agent\n"
 		"-N\tJust don't use any proxy server\n"
@@ -642,6 +652,8 @@ void print_help()
 		"--max-redirect=x\tSpecify maximum number of redirections\n"
 		"--output=f\t\t-o f\tSpecify local output file\n"
 		"--search[=x]\t\t-S [x]\tSearch for mirrors and download from x servers\n"
+		"--ipv4\t\t-4\tUse the IPv4 protocol\n"
+		"--ipv6\t\t-6\tUse the IPv6 protocol\n"
 		"--header=x\t\t-H x\tAdd header string\n"
 		"--user-agent=x\t\t-U x\tSet user agent\n"
 		"--no-proxy\t\t-N\tJust don't use any proxy server\n"


### PR DESCRIPTION
Solves #40 

===========================

Like wget, enable the user to choose the IP protocol to use.
This can now be done using the long opt "use-protocol=[ipv4,ipv6]"
in the axelrc file or by using the related command line options
--ipv4/-4 and --ipv6/-6.

Signed-off-by: Antonio Quartulli <a@unstable.cc>