### PR TITLE
Let travis-ci compile with -Werror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
     - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
         export OSX_FLAGS="-I/usr/local/opt/openssl/include";
       fi
-    - ./autogen.sh && ./configure CFLAGS="-O3 $OSX_FLAGS" && make
+    - ./autogen.sh && ./configure CFLAGS="-O3 -Werror $OSX_FLAGS" && make


### PR DESCRIPTION
This way travis-ci will fail if a new warning is
detected and give a chance to the developers to notice
that.

Signed-off-by: Antonio Quartulli <a@unstable.cc>