### PR TITLE
netrc: Implement .netrc parsing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,8 @@ axel_SOURCES = \
 	src/ftp.h \
 	src/http.c \
 	src/http.h \
+	src/netrc.c \
+	src/netrc.h \
 	src/search.c \
 	src/search.h \
 	src/ssl.c \

--- a/src/conf.h
+++ b/src/conf.h
@@ -42,8 +42,9 @@
 #ifndef AXEL_CONF_H
 #define AXEL_CONF_H
 
+#include "netrc.h"
+
 typedef struct {
-	char netrc_filename[MAX_STRING];
 	char default_filename[MAX_STRING];
 	char http_proxy[MAX_STRING];
 	char no_proxy[MAX_STRING];
@@ -68,7 +69,7 @@ typedef struct {
 	int search_threads;
 	int search_amount;
 	int search_top;
-	int use_netrc;
+	netrc_t *netrc;
 
 	unsigned io_timeout;
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -162,7 +162,7 @@ conn_set(conn_t *conn, const char *set_url)
 	}
 
 	/* Uses .netrc info if enabled and creds have not been provided */
-	if ((!conn->user || !*(conn->user)) && conn->conf->netrc) {
+	if (!conn->user || !*conn->user) {
 		netrc_parse(conn->conf->netrc, conn->host,
 			    conn->user, sizeof(conn->user),
 			    conn->pass, sizeof(conn->pass));

--- a/src/conn.c
+++ b/src/conn.c
@@ -255,7 +255,7 @@ conn_init(conn_t *conn)
 		conn->ftp->ftp_mode = FTP_PASSIVE;
 		conn->ftp->tcp.ai_family = conn->conf->ai_family;
 		if (conn->conf->use_netrc)
-			netrc_parse(conn->conf->netrc_filename, conn->host, conn->user, conn->pass);
+			netrc_parse(conn->conf->netrc_filename, conn->host, conn->user, sizeof(conn->user), conn->pass, sizeof(conn->pass));
 		printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
 		if (!ftp_connect(conn->ftp, conn->proto, conn->host, conn->port,
 				 conn->user, conn->pass,

--- a/src/conn.c
+++ b/src/conn.c
@@ -43,6 +43,7 @@
 /* Connection stuff */
 
 #include "axel.h"
+#include "netrc.h"
 
 /**
  * Convert an URL to a conn_t structure.
@@ -253,6 +254,8 @@ conn_init(conn_t *conn)
 		conn->ftp->local_if = conn->local_if;
 		conn->ftp->ftp_mode = FTP_PASSIVE;
 		conn->ftp->tcp.ai_family = conn->conf->ai_family;
+		if (conn->conf->use_netrc)
+			netrc_parse(conn);
 		if (!ftp_connect(conn->ftp, conn->proto, conn->host, conn->port,
 				 conn->user, conn->pass,
 				 conn->conf->io_timeout)) {

--- a/src/conn.c
+++ b/src/conn.c
@@ -167,7 +167,7 @@ conn_set(conn_t *conn, const char *set_url)
 		netrc_parse(conn->conf->netrc, conn->host,
 			    conn->user, sizeof(conn->user),
 			    conn->pass, sizeof(conn->pass));
-		netrc_close(conn->conf->netrc);
+		netrc_free(conn->conf->netrc);
 	}
 	printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -254,9 +254,13 @@ conn_init(conn_t *conn)
 		conn->ftp->local_if = conn->local_if;
 		conn->ftp->ftp_mode = FTP_PASSIVE;
 		conn->ftp->tcp.ai_family = conn->conf->ai_family;
-		if (conn->conf->use_netrc)
-			netrc_parse(conn->conf->netrc_filename, conn->host, conn->user, sizeof(conn->user), conn->pass, sizeof(conn->pass));
-		printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
+		if (conn->conf->use_netrc) {
+			netrc_t * netrc;
+			netrc = netrc_init(conn->conf->netrc_filename, conn->host, conn->user, sizeof(conn->user), conn->pass, sizeof(conn->pass));
+			netrc_parse(netrc);
+			printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
+			netrc_close(netrc);
+		}
 		if (!ftp_connect(conn->ftp, conn->proto, conn->host, conn->port,
 				 conn->user, conn->pass,
 				 conn->conf->io_timeout)) {

--- a/src/conn.c
+++ b/src/conn.c
@@ -255,7 +255,8 @@ conn_init(conn_t *conn)
 		conn->ftp->ftp_mode = FTP_PASSIVE;
 		conn->ftp->tcp.ai_family = conn->conf->ai_family;
 		if (conn->conf->use_netrc)
-			netrc_parse(conn);
+			netrc_parse(conn->conf->netrc_filename, conn->host, conn->user, conn->pass);
+		printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
 		if (!ftp_connect(conn->ftp, conn->proto, conn->host, conn->port,
 				 conn->user, conn->pass,
 				 conn->conf->io_timeout)) {

--- a/src/conn.c
+++ b/src/conn.c
@@ -43,7 +43,6 @@
 /* Connection stuff */
 
 #include "axel.h"
-#include "netrc.h"
 
 /**
  * Convert an URL to a conn_t structure.
@@ -167,7 +166,6 @@ conn_set(conn_t *conn, const char *set_url)
 		netrc_parse(conn->conf->netrc, conn->host,
 			    conn->user, sizeof(conn->user),
 			    conn->pass, sizeof(conn->pass));
-		netrc_free(conn->conf->netrc);
 	}
 	printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -254,12 +254,10 @@ conn_init(conn_t *conn)
 		conn->ftp->local_if = conn->local_if;
 		conn->ftp->ftp_mode = FTP_PASSIVE;
 		conn->ftp->tcp.ai_family = conn->conf->ai_family;
-		if (conn->conf->use_netrc) {
-			netrc_t * netrc;
-			netrc = netrc_init(conn->conf->netrc_filename, conn->host, conn->user, sizeof(conn->user), conn->pass, sizeof(conn->pass));
-			netrc_parse(netrc);
+		if (conn->conf->netrc) {
+			netrc_parse(conn->conf->netrc, conn->host, conn->user, sizeof(conn->user), conn->pass, sizeof(conn->pass));
+			netrc_close(conn->conf->netrc);
 			printf("host: %s, user: %s, pass: %s\n", conn->host, conn->user, conn->pass);
-			netrc_close(netrc);
 		}
 		if (!ftp_connect(conn->ftp, conn->proto, conn->host, conn->port,
 				 conn->user, conn->pass,

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -197,25 +197,20 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 				break;
 			if (tok.data[0] == 'm') {
 				tok = memtok(NULL, 0, tok_delim, &save_buf);
-				if (!strncmp(host, tok.data, tok.len))
-					matched = true;
-			} else if (tok.data[0] == 'd') {
+				matched = !strncmp(host, tok.data, tok.len);
+			} else {
 				matched = true;
 			}
 		} else {
 			tok = memtok(NULL, 0, tok_delim, &save_buf);
 			if (matched) {
 				// FIXME should we be aborting?
-				if (tok.len >= p->len) {
+				if (tok.len >= p->len)
 					tok.len = p->len - 1;
-					p->dst[tok.len] = 0;
-				}
-
-				/* need strlcpy here, as tok.data isn't NULL-terminated */
-				strlcpy(p->dst, tok.data, tok.len + 1);
+				memcpy(p->dst, tok.data, tok.len);
+				p->dst[tok.len] = 0;
 			}
 		}
-
 		tok = memtok(NULL, 0, tok_delim, &save_buf);
 	}
 	return 1;

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -164,12 +164,12 @@ netrc_init(const char *path)
 	return NULL;
 }
 
-int
+void
 netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char *pass, size_t pass_len)
 {
 	bool matched = false;
 	buffer_t tok, save_buf = {};
-	struct parser {
+	const struct parser {
 		const char * const key;
 		char *dst;
 		size_t len;
@@ -183,16 +183,17 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 
 	tok = memtok(netrc->s_addr, netrc->sz, tok_delim, &save_buf);
 	while (tok.len) {
-		struct parser *p = parser;
+		const struct parser *p = parser;
 		while (p < parser + parser_len && strncmp(p->key, tok.data, tok.len))
 			p++;
 
 		/* unknown token? -> abort */
 		if (p >= parser + parser_len)
-			return 0;
+			return;
 
 		/* next "machine"/"default" entry */
 		if (!p->dst) {
+			/* if we already got one, we're done */
 			if (matched)
 				break;
 			if (tok.data[0] == 'm') {
@@ -213,5 +214,4 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 		}
 		tok = memtok(NULL, 0, tok_delim, &save_buf);
 	}
-	return 1;
 }

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -181,6 +181,9 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 	};
 	enum { parser_len = sizeof(parser) / sizeof(*parser), };
 
+	if (!netrc)
+		return;
+
 	tok = memtok(netrc->s_addr, netrc->sz, tok_delim, &save_buf);
 	while (tok.len) {
 		const struct parser *p = parser;

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -155,7 +155,8 @@ get_creds(netrc_t *netrc, char *user, size_t user_len, char *pass, size_t pass_l
 			tok = memtok(NULL, 0, tok_delim, &save_buf);
 			if (tok.len <= pass_len)
 				strlcpy(pass, tok.data, tok.len+1);
-		} else if (!strncmp("machine", tok.data, tok.len) || !strncmp("default", tok.data, tok.len)) {
+		} else if (!strncmp("machine", tok.data, tok.len) ||
+			   !strncmp("default", tok.data, tok.len)) {
 			save_buf.data -= tok.len;
 			save_buf.len += tok.len;
 			break;

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -44,6 +44,11 @@
 #include "axel.h"
 #include "netrc.h"
 
+struct netrc{
+	size_t sz;
+	char *s_addr;
+};
+
 typedef struct {
 	char *data;
 	size_t len;

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -41,75 +41,95 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include "axel.h"
 #include "netrc.h"
 
-#define REL_NETRC	"/.netrc"
-#define IS_DELIM(x)	(*x == ' ' || *x == '\t' || *x == '\n')
-
-static int fd;
-static size_t sz;
 static char *p;
 static char *s_addr;
 static char *e_addr;
 
-static size_t file_size(void)
+static size_t file_size(int fd)
 {
 	struct stat st;
 	fstat(fd, &st);
 	return st.st_size;
 }
 
-static int netrc_open(const char * const filename)
+static int netrc_mmap(const char *filename)
 {
-	int ret;
-	char *path;
-	char *netrc;
-	char *home;
+	int fd;
+	size_t sz;
+	char *aux = NULL;
+	char *home = NULL;
+	char *path = NULL;
+	const char suffix[] = "/.netrc";
 
-	ret = 0;
-	if (filename && filename[0] != '\0') {
-		path = strdup(filename);
-	} else {
-		if ((netrc = getenv("NETRC"))) {
-			path = strdup(netrc);
-		} else if ((home = getenv("HOME"))) {
-			size_t i = strlen(home) + strlen(REL_NETRC) + 1;
-			path = malloc(i);
-			snprintf(path, i, "%s%s", home, REL_NETRC);
-		} else {
-			return ret;
+	if (filename && *filename) {
+		aux = path = (char *)filename;
+	} else if ((path = getenv("NETRC"))) {
+		aux = path;
+	} else if ((home = getenv("HOME"))) {
+		size_t i = strlen(home);
+		if ((path = malloc(i + sizeof(suffix)))) {
+			memcpy(path, home, i);
+			memcpy(path+i, suffix, sizeof(suffix));
 		}
 	}
-	if ((fd = open(path, O_RDONLY, 0)) == -1) {
-		ret = 0;
+	if (!path)
+		return 0;
+	fd = open(path, O_RDONLY,0);
+	if (!aux)
+		free(path);
+	if (fd == -1) {
+		return 0;
 	} else {
-		sz = file_size();
+		sz = file_size(fd);
 		s_addr = mmap(NULL, sz, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+		close(fd);
 		e_addr = s_addr + sz;
-		ret = 1;
+		return sz;
 	}
-	free(path);
-	return ret;
 }
 
-static void netrc_close(void)
+static void netrc_munmap(size_t sz)
 {
 	munmap(s_addr, sz);
-	close(fd);
 }
 
-static int next_token(char **t)
+static size_t
+memspn(const char *s, const char *t, size_t len)
+{
+	size_t sz = 0;
+
+	while (*s && len-- && strchr(t, *s++))
+		sz++;
+	return sz;
+}
+
+static size_t
+memcspn(const char *s, const char *t, size_t len)
+{
+	size_t sz = 0;
+
+	while (*s && len--)
+		if (strchr(t, *s))
+			return sz;
+		else
+			s++, sz++;
+	return sz;
+}
+
+static size_t next_token(char **t)
 {
 	char *q;
-	int len;
+	size_t len;
+	const char *delims = " \t\n";
 
 	if (!p)
 		p = s_addr;
-	while (IS_DELIM(p) && p < e_addr)
-		p++;
+	p += memspn(p, delims, (e_addr - p));
 	q = p;
-	while (!IS_DELIM(q) && q < e_addr)
-		q++;
+	q += memcspn(q, delims, (e_addr - q));
 	if (q == e_addr)
 		return 0;
 	len = q-p;
@@ -118,20 +138,22 @@ static int next_token(char **t)
 	return len;
 }
 
-static void get_creds(char *user, char *pwd)
+static void
+get_creds(char *user, size_t ul, char *pwd, size_t pl)
 {
-	int len;
+	size_t len;
 	char *tok;
 
 	while ((len = next_token(&tok))) {
 		if (!strncmp("login", tok, len)) {
 			len = next_token(&tok);
-			strncpy(user, tok, len);
-			user[len] = '\0';
+			/* next_token() doesn't null-terminate */
+			if (len <= ul)
+				strlcpy(user, tok, len+1);
 		} else if (!strncmp("password", tok, len)) {
 			len = next_token(&tok);
-			strncpy(pwd, tok, len);
-			pwd[len] = '\0';
+			if (len <= pl)
+				strlcpy(pwd, tok, len+1);
 		} else if (!strncmp("machine", tok, len) || !strncmp("default", tok, len)) {
 			p -= len;
 			break;
@@ -140,24 +162,26 @@ static void get_creds(char *user, char *pwd)
 }
 
 int
-netrc_parse(const char *filename, const char *host, char *user, char *password)
+netrc_parse(const char *filename, const char *host,
+	    char *user, size_t ul, char *password, size_t pl)
 {
-	int len;
+	size_t len;
+	size_t sz;
 	char *tok;
 
-	if (!netrc_open(filename))
+	if (!(sz = netrc_mmap(filename)))
 		return 0;
 	while ((len = next_token(&tok))) {
 		if (!strncmp("default", tok, len)) {
-			get_creds(user, password);
+			get_creds(user, ul, password, pl);
 			break;
 		} else if (!strncmp("machine", tok, len)) {
 			if ((len = next_token(&tok)) && !strncmp(host, tok, len)) {
-				get_creds(user, password);
+				get_creds(user, ul, password, pl);
 				break;
 			}
 		}
 	}
-	netrc_close();
-	return 0;
+	netrc_munmap(sz);
+	return 1;
 }

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -1,0 +1,114 @@
+/*
+  Axel -- A lighter download accelerator for Linux and other Unices
+
+  Copyright 2019      David da Silva Polverari
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  In addition, as a special exception, the copyright holders give
+  permission to link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each
+  individual source file, and distribute linked combinations including
+  the two.
+
+  You must obey the GNU General Public License in all respects for all
+  of the code used other than OpenSSL. If you modify file(s) with this
+  exception, you may extend this exception to your version of the
+  file(s), but you are not obligated to do so. If you do not wish to do
+  so, delete this exception statement from your version. If you delete
+  this exception statement from all source files in the program, then
+  also delete it here.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+/* .netrc parsing implementation */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include "axel.h"
+#include "netrc.h"
+
+enum lookup_state {
+	NOTHING,
+	DEFAULT,
+	MACHINE,
+	HOST_ENTRY,
+	LOGIN,
+	PASSWORD
+};
+
+void
+netrc_parse(conn_t *conn)
+{
+	FILE *fp;
+	bool found = false;
+	char *home;
+	char *tok, *ntok;
+	char line[MAX_STRING];
+	char const *delims = " \t\n";
+	enum lookup_state state = NOTHING;
+
+	if (conn->conf->netrc_filename[0] == '\0') {
+		home = getenv("HOME");
+		snprintf(conn->conf->netrc_filename, MAX_STRING, "%s/.netrc", home);
+	}
+	if ((fp = fopen(conn->conf->netrc_filename, "r")) == NULL)
+		return;
+	while (!found && fgets(line, MAX_STRING, fp)) {
+		tok = strtok_r(line, delims, &ntok);
+		if (tok && *tok == '#')
+			continue;
+		while (tok != NULL) {
+			switch (state) {
+			case NOTHING:
+				if (!strcmp("machine", tok)) {
+					state = MACHINE;
+				} else if (!strcmp("default", tok)) {
+					state = DEFAULT;
+				}
+				break;
+			case MACHINE:
+				if (!strcmp(conn->host, tok)) {
+					state = HOST_ENTRY;
+				} else {
+					state = NOTHING;
+				}
+				break;
+			case DEFAULT:
+				state = HOST_ENTRY;
+				// fall through
+			case HOST_ENTRY:
+				if (!strcmp("login", tok)) {
+					state = LOGIN;
+				} else if (!strcmp("password", tok)) {
+					state = PASSWORD;
+				}
+				break;
+			case LOGIN:
+				strcpy(conn->user, tok);
+				state = HOST_ENTRY;
+				break;
+			case PASSWORD:
+				strcpy(conn->pass, tok);
+				found = true;
+				break;
+			default:
+				break;
+			}
+			tok = strtok_r(NULL, delims, &ntok);
+		}
+	}
+}

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -181,12 +181,9 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 	};
 	enum { parser_len = sizeof(parser) / sizeof(*parser), };
 
-	if (NULL == netrc)
-		return 0;
-
 	tok = memtok(netrc->s_addr, netrc->sz, tok_delim, &save_buf);
 	while (tok.len) {
-		const struct parser *p = parser;
+		struct parser *p = parser;
 		while (p < parser + parser_len && strncmp(p->key, tok.data, tok.len))
 			p++;
 
@@ -202,7 +199,7 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 				tok = memtok(NULL, 0, tok_delim, &save_buf);
 				if (!strncmp(host, tok.data, tok.len))
 					matched = true;
-			} else {
+			} else if (tok.data[0] == 'd') {
 				matched = true;
 			}
 		} else {
@@ -211,10 +208,11 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 				// FIXME should we be aborting?
 				if (tok.len >= p->len) {
 					tok.len = p->len - 1;
+					p->dst[tok.len] = 0;
 				}
 
-				memcpy(p->dst, tok.data, tok.len + 1);
-				p->dst[tok.len] = 0;
+				/* need strlcpy here, as tok.data isn't NULL-terminated */
+				strlcpy(p->dst, tok.data, tok.len + 1);
 			}
 		}
 

--- a/src/netrc.c
+++ b/src/netrc.c
@@ -181,9 +181,12 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 	};
 	enum { parser_len = sizeof(parser) / sizeof(*parser), };
 
+	if (NULL == netrc)
+		return 0;
+
 	tok = memtok(netrc->s_addr, netrc->sz, tok_delim, &save_buf);
 	while (tok.len) {
-		struct parser *p = parser;
+		const struct parser *p = parser;
 		while (p < parser + parser_len && strncmp(p->key, tok.data, tok.len))
 			p++;
 
@@ -199,7 +202,7 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 				tok = memtok(NULL, 0, tok_delim, &save_buf);
 				if (!strncmp(host, tok.data, tok.len))
 					matched = true;
-			} else if (tok.data[0] == 'd') {
+			} else {
 				matched = true;
 			}
 		} else {
@@ -208,11 +211,10 @@ netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char 
 				// FIXME should we be aborting?
 				if (tok.len >= p->len) {
 					tok.len = p->len - 1;
-					p->dst[tok.len] = 0;
 				}
 
-				/* need strlcpy here, as tok.data isn't NULL-terminated */
-				strlcpy(p->dst, tok.data, tok.len + 1);
+				memcpy(p->dst, tok.data, tok.len + 1);
+				p->dst[tok.len] = 0;
 			}
 		}
 

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -40,6 +40,8 @@
 typedef struct netrc netrc_t;
 
 netrc_t *netrc_init(const char *netrc_filename);
-int netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);
+void netrc_parse(netrc_t *netrc, const char *host,
+		 char *user, size_t user_len,
+		 char *pass, size_t pass_len);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -38,11 +38,12 @@
 #define AXEL_NETRC_H
 
 typedef struct {
-	const char *file;
+	size_t sz;
+	char *s_addr;
 } netrc_t;
 
-netrc_t *netrc_init(const char *file);
+netrc_t *netrc_init(const char *netrc_filename);
 int netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);
-void netrc_close(netrc_t *netrc);
+void netrc_free(netrc_t *netrc);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -1,12 +1,7 @@
 /*
   Axel -- A lighter download accelerator for Linux and other Unices
 
-  Copyright 2001-2007 Wilmer van der Gaast
-  Copyright 2008      Philipp Hagemeister
-  Copyright 2008      Y Giridhar Appaji Nag
-  Copyright 2016      Stephen Thirlwall
-  Copyright 2017      Antonio Quartulli
-  Copyright 2017      Ismael Luceno
+  Copyright 2019      David da Silva Polverari
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License
@@ -37,58 +32,11 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-/* Configuration handling include file */
+/* .netrc parsing include file */
 
-#ifndef AXEL_CONF_H
-#define AXEL_CONF_H
+#ifndef AXEL_NETRC_H
+#define AXEL_NETRC_H
 
-typedef struct {
-	char netrc_filename[MAX_STRING];
-	char default_filename[MAX_STRING];
-	char http_proxy[MAX_STRING];
-	char no_proxy[MAX_STRING];
-	uint16_t num_connections;
-	int strip_cgi_parameters;
-	int save_state_interval;
-	int connection_timeout;
-	int reconnect_delay;
-	int max_redirect;
-	int buffer_size;
-	int max_speed;
-	int verbose;
-	int alternate_output;
-	int insecure;
-	int no_clobber;
+void netrc_parse(conn_t *conn);
 
-	if_t *interfaces;
-
-	sa_family_t ai_family;
-
-	int search_timeout;
-	int search_threads;
-	int search_amount;
-	int search_top;
-	int use_netrc;
-
-	unsigned io_timeout;
-
-	int add_header_count;
-	char add_header[MAX_ADD_HEADERS][MAX_STRING];
-} conf_t;
-
-int conf_loadfile(conf_t *conf, const char *file);
-int conf_init(conf_t *conf);
-void conf_free(conf_t *conf);
-
-enum {
-	HDR_USER_AGENT,
-	HDR_count_init,
-};
-
-inline static void
-conf_hdr_make(char *dst, const char *k, const char *v)
-{
-	snprintf(dst, sizeof(((conf_t *)0)->add_header[0]), "%s: %s", k, v);
-}
-
-#endif				/* AXEL_CONF_H */
+#endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -37,6 +37,6 @@
 #ifndef AXEL_NETRC_H
 #define AXEL_NETRC_H
 
-void netrc_parse(conn_t *conn);
+int netrc_parse(const char *filename, const char *host, char *user, char *pwd);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -37,6 +37,6 @@
 #ifndef AXEL_NETRC_H
 #define AXEL_NETRC_H
 
-int netrc_parse(const char *filename, const char *host, char *user, char *pwd);
+int netrc_parse(const char *filename, const char *host, char *user, size_t ul, char *pwd, size_t pl);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -39,15 +39,10 @@
 
 typedef struct {
 	const char *file;
-	const char *host;
-	char *user;
-	size_t user_len;
-	char *pass;
-	size_t pass_len;
 } netrc_t;
 
-netrc_t *netrc_init(const char *file, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);
-int netrc_parse(netrc_t *netrc);
+netrc_t *netrc_init(const char *file);
+int netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);
 void netrc_close(netrc_t *netrc);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -41,6 +41,5 @@ typedef struct netrc netrc_t;
 
 netrc_t *netrc_init(const char *netrc_filename);
 int netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);
-void netrc_free(netrc_t *netrc);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -37,6 +37,17 @@
 #ifndef AXEL_NETRC_H
 #define AXEL_NETRC_H
 
-int netrc_parse(const char *filename, const char *host, char *user, size_t ul, char *pwd, size_t pl);
+typedef struct {
+	const char *file;
+	const char *host;
+	char *user;
+	size_t user_len;
+	char *pass;
+	size_t pass_len;
+} netrc_t;
+
+netrc_t *netrc_init(const char *file, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);
+int netrc_parse(netrc_t *netrc);
+void netrc_close(netrc_t *netrc);
 
 #endif				/* AXEL_NETRC_H */

--- a/src/netrc.h
+++ b/src/netrc.h
@@ -37,10 +37,7 @@
 #ifndef AXEL_NETRC_H
 #define AXEL_NETRC_H
 
-typedef struct {
-	size_t sz;
-	char *s_addr;
-} netrc_t;
+typedef struct netrc netrc_t;
 
 netrc_t *netrc_init(const char *netrc_filename);
 int netrc_parse(netrc_t *netrc, const char *host, char *user, size_t user_len, char *pass, size_t pass_len);

--- a/src/text.c
+++ b/src/text.c
@@ -165,7 +165,8 @@ main(int argc, char *argv[])
 		case 'R':
 			conf->use_netrc = 1;
 			if (optarg) {
-				if (!sscanf(optarg, "%s", conf->netrc_filename)) {
+				if (!strlcpy(conf->netrc_filename, optarg, 
+				     sizeof(conf->netrc_filename))) {
 					print_help();
 					goto free_conf;
 				}

--- a/src/text.c
+++ b/src/text.c
@@ -163,13 +163,7 @@ main(int argc, char *argv[])
 			}
 			break;
 		case 'R':
-			{
-				char *netrc_filename = NULL;
-				if (optarg) {
-					netrc_filename = optarg;
-				}
-				conf->netrc = netrc_init(netrc_filename);
-			}
+			conf->netrc = netrc_init(optarg ? optarg : NULL);
 			break;
 		case '6':
 			conf->ai_family = AF_INET6;

--- a/src/text.c
+++ b/src/text.c
@@ -165,7 +165,7 @@ main(int argc, char *argv[])
 		case 'R':
 			conf->use_netrc = 1;
 			if (optarg) {
-				if (!strlcpy(conf->netrc_filename, optarg, 
+				if (!strlcpy(conf->netrc_filename, optarg,
 				     sizeof(conf->netrc_filename))) {
 					print_help();
 					goto free_conf;

--- a/src/text.c
+++ b/src/text.c
@@ -71,6 +71,7 @@ static struct option axel_options[] = {
 	{"max-redirect",    1,      NULL, MAX_REDIR_OPT},
 	{"output",          1,      NULL, 'o'},
 	{"search",          2,      NULL, 'S'},
+	{"netrc",           2,      NULL, 'R'},
 	{"ipv4",            0,      NULL, '4'},
 	{"ipv6",            0,      NULL, '6'},
 	{"no-proxy",        0,      NULL, 'N'},
@@ -117,7 +118,7 @@ main(int argc, char *argv[])
 	j = -1;
 	while (1) {
 		int option = getopt_long(argc, argv,
-					 "s:n:o:S::46NqvhVakcH:U:T:",
+					 "s:n:o:S::R::46NqvhVakcH:U:T:",
 					 axel_options, NULL);
 		if (option == -1)
 			break;
@@ -156,6 +157,15 @@ main(int argc, char *argv[])
 			do_search = 1;
 			if (optarg) {
 				if (!sscanf(optarg, "%i", &conf->search_top)) {
+					print_help();
+					goto free_conf;
+				}
+			}
+			break;
+		case 'R':
+			conf->use_netrc = 1;
+			if (optarg) {
+				if (!sscanf(optarg, "%s", conf->netrc_filename)) {
 					print_help();
 					goto free_conf;
 				}
@@ -659,6 +669,7 @@ print_help(void)
 		 "-n x\tSpecify maximum number of connections\n"
 		 "-o f\tSpecify local output file\n"
 		 "-S[n]\tSearch for mirrors and download from n servers\n"
+		 "-R[file]\tRetrieve credentials from $HOME/.netrc file or filename\n"
 		 "-4\tUse the IPv4 protocol\n"
 		 "-6\tUse the IPv6 protocol\n"
 		 "-H x\tAdd HTTP header string\n"
@@ -682,6 +693,7 @@ print_help(void)
 		 "--max-redirect=x\t\tSpecify maximum number of redirections\n"
 		 "--output=f\t\t-o f\tSpecify local output file\n"
 		 "--search[=n]\t\t-S[n]\tSearch for mirrors and download from n servers\n"
+		 "--netrc[=file]\t\t-R[file]\tRetrieve credentials from $HOME/.netrc file or filename\n"
 		 "--ipv4\t\t\t-4\tUse the IPv4 protocol\n"
 		 "--ipv6\t\t\t-6\tUse the IPv6 protocol\n"
 		 "--header=x\t\t-H x\tAdd HTTP header string\n"

--- a/src/text.c
+++ b/src/text.c
@@ -163,13 +163,12 @@ main(int argc, char *argv[])
 			}
 			break;
 		case 'R':
-			conf->use_netrc = 1;
-			if (optarg) {
-				if (!strlcpy(conf->netrc_filename, optarg,
-				     sizeof(conf->netrc_filename))) {
-					print_help();
-					goto free_conf;
+			{
+				char *netrc_filename = NULL;
+				if (optarg) {
+					netrc_filename = optarg;
 				}
+				conf->netrc = netrc_init(netrc_filename);
 			}
 			break;
 		case '6':

--- a/src/text.c
+++ b/src/text.c
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
 			}
 			break;
 		case 'R':
-			conf->netrc = netrc_init(optarg ? optarg : NULL);
+			conf->netrc = netrc_init(optarg);
 			break;
 		case '6':
 			conf->ai_family = AF_INET6;


### PR DESCRIPTION
This implementation parses the $HOME/.netrc (or a file specified by the
user) through the `--netrc[=file]` or `-R[file]` options.

It uses a simple FSM in order to parse the file and find the credentials
corresponding to the FTP host, or uses the "default" entry otherwise,
if any, according to the specification found on [1]. Tokens not
applicable to axel usage were not considered.

[1] https://docs.oracle.com/cd/E19455-01/806-0633/6j9vn6q5f/index.html

Closes: #116

Signed-off-by: David Polverari <david.polverari@gmail.com>