### PR TITLE
Fix connection setup_thread join logic (issue #411)

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -20,82 +20,82 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Buffer für diese Geschwindigkeit angepasst."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "Kann URL nicht parsen.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "Datei '%s' bereits vorhanden; nicht abrufen.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr ""
 "Es wurde ein unvollständiger Download gefunden, die No-Clobber-Option wurde "
 "ignoriert\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "FEHLER %d: %s.\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Dateigröße: %s (%jd bytes)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "Dateigröße: nicht verfügbar"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Öffne Ausgabedatei: %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Server versteht REST nicht, Neustart mit einer Verbindung."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Fehler, abgeschnittene Statusdatei\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Falsche Anzahl in der Statusdatei gespeicherten Verbindungen\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Statusdatei hat altes Format.\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Status-Datei gefunden: %jd bytes übertragen, %jd verbleiben."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Fehler beim Öffnen der lokalen Datei"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Schlechtes Datei-/Betriebssystem, Umgehung.."
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Fehler beim Erstellen der lokalen Datei"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -104,60 +104,60 @@ msgstr ""
 "\n"
 "Verbindung %d wieder aktivieren\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Starte Abruf"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Verbindung %i: Abruf von %s:%i über Schnittstelle %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread Fehler!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Fehler beim Warten auf Verbindung: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Time-out bei Verbindung %i"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Fehler bei Verbindung %i! Verbindung getrennt"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Verbindung %i unerwartet getrennt"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Verbindung %i beendet"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Schreibfehler!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Fehler beim Erzwingen der Drosselung: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr ""
 "Es sind zu wenige Bytes übrig, also eine einzelne Verbindung erzwingen\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "Herunterladen von %jd-%jd mithilfe der Verbindung %i\n"

--- a/po/es.po
+++ b/po/es.po
@@ -20,80 +20,80 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Buffer redimensionado para ésta velocidad."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "No se puede analizar la URL.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "Archivo '%s' ya existe; no recuperando.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "Descarga incompleta encontrada, ignorando opción no-clobber\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "ERROR %d: %s.\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Tamaño de archivo: %s (%jd bytes)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "Tamaño de archivo: no disponible"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Abriendo archivo de salida %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Servidor no soportado, comenzando desde cero con una conexión."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Error, archivo de estado truncado\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Número incorrecto de conexiones almacenado en el archivo de estado\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Archivo de estado en formato antiguo.\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Archivo de estado encontrado: %jd bytes descargados, %jd pendientes."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Error abriendo archivo local"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Sistema de archivos/SO horrible. Usando solución alternativa. :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Error creando archivo local"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -102,59 +102,59 @@ msgstr ""
 "\n"
 "Reactivar conexión %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Comenzando descarga"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Conexión %i descargando desde %s:%i usando la interfaz %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "error de pthread!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Error al esperar por conexión: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Conexión %i caducada"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Error en conexión %i! Conexión cerrada"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Conexión %i cerrada inesperadamente"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Conexión %i finalizada"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Error de escritura!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Error al aplicar regulación: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "Quedan muy pocos bytes, forzando una única conexión\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "Descargando %jd-%jd usando conn. %i\n"

--- a/po/id_ID.po
+++ b/po/id_ID.po
@@ -18,81 +18,81 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Buffer diubah ukurannya untuk kecepatan ini."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "Tidak bisa mengurai URL.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "Berkas '%s' sudah ada; tidak mengambil.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "Unduhan tidak lengkap ditemukan, mengabaikan opsi no-clobber\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr ""
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, fuzzy, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Ukuran berkas: %s (%jd bytes)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 #, fuzzy
 msgid "File size: unavailable"
 msgstr "Ukuran berkas: tidak tersedia"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Membuka berkas keluaran %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Server tidak didukung, mulai dari dasar dengan satu koneksi."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Galat, bagian berkas terpotong\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Jumlah koneksi palsu tersimpan dalam bagian berkas\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Bagian berkas memiliki format lama..\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, fuzzy, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Bagian berkas ditemukan: %jd bytes diunduh, %jd untuk berjalan."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Galat saat membuka berkas lokal"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Filesystem/OS jelek.. Bekerja di sekitar. :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Galat membuat berkas lokal"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -101,59 +101,59 @@ msgstr ""
 "\n"
 "Aktifkan kembali koneksi %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Mulai mengunduh"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Sambungan %i diunduh dari %s:%i menggunakan antarmuka %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread galat!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Galat saat menunggu koneksi: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Sambungan %i habis waktunya"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Galat pada koneksi %i! Sambungan putus"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Koneksi %i tiba-tiba putus"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Koneksi %i selesai"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Tulis galat!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Galat saat menerapkan throttling: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr ""
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, fuzzy, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "Mengunduh %jd-%jd menggunakan conn. %i\n"

--- a/po/it.po
+++ b/po/it.po
@@ -22,80 +22,80 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Buffer ridimensionato per questa velocità."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "Impossibile interpretare l'URL.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "Il file '%s' è già presente; download non effettuato.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "Trovato download incompleto, ignoro l'opzione \"no-clobber\"\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "ERRORE %d: %s.\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Dimensione file: %s (%jd byte)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "Dimensione file: non disponibile"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Sto aprendo il file di output %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Server non supportato, sto ricominciando da zero con una connessione."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Errore, file di stato troncato\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Numero errato di connessioni memorizzate nel file di stato\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Il file di stato utilizza il vecchio formato.\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Trovato file di stato: %jd byte scaricati, %jd al termine."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Errore nell'apertura del file locale"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Filesystem/OS scadente.. Raggiro il problema. :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Errore nella creazione del file locale"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -104,59 +104,59 @@ msgstr ""
 "\n"
 "Riattivando la connessione %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Inizio download"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "La connessione %i sta scaricando da %s:%i usando l'interfaccia %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "Errore pthread!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Errore durante l'attesa della connessione: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Connessione %i scaduta"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Errore nella connessione %i! Connessione terminata"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Connessione %i terminata inaspettatamente"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Connessione %i terminata"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Errore di scrittura!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Errore nell'applicazione del limite di velocità: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "Restano pochi byte, forzando una singola connessione\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "Scaricando %jd-%jd usando la conn. %i\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -14,84 +14,84 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "このスピードに合わせバッファーをリサイズします。"
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "URL を解析できません。\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "ファイル '%s' はすでに存在します。 だからそれは取得されません。\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr ""
 "不完全なダウンロードが見つかりましたが、no-clobberオプションは無視されます\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "エラー %d: %s.\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, fuzzy, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "ファイルサイズ: %s (%jd バイト)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 #, fuzzy
 msgid "File size: unavailable"
 msgstr "ファイルサイズ: 利用不可"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "出力ファイル %s をオープンします"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr ""
 "サポートされていないサーバーなので、単一コネクションを使い最初から始めます。"
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: エラー、状態ファイルが切り捨てられました\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "状態ファイルに保存されている接続の偽の数\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "状態ファイルは古い形式です。\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, fuzzy, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "状態ファイル発見: %jd バイトがダウンロード済み、あと %jd バイト。"
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "ローカルファイルをオープンする際にエラー発生しました"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "ファイルシステム/OSがイマイチ。回避します。 :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 #, fuzzy
 msgid "Error creating local file"
 msgstr "ローカルファイルをオープンする際にエラー発生しました"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -100,59 +100,59 @@ msgstr ""
 "\n"
 "接続 %d を再アクティブ化しています\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "ダウンロード開始します"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "接続 %i は %s:%i から、インターフェース %s でダウンロードします"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread のエラー!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, fuzzy, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "コマンド %s を書く際にエラー\n"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "接続 %i がタイムアウトしました"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "接続 %i でエラー! コネクションをクローズしました"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "接続 %i が不意にクローズされました"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "接続 %i が終了しました"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "書き込みエラー!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "調整を強制している間のエラー: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "残りのバイト数が少なすぎて、単一接続が強制される\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, fuzzy, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "%jd-%jd をダウンロード中、接続 %i を使用して\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -12,81 +12,81 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "ბუფერის ზომა ამ სიჩქარისთვის შეიცვლება."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "URL-ის დამუშავების შეცდომა\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "ფაილი '%s' უკვე გვაქვს; აღარ გადმოვიწერ.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "გადმოწერა არასრულია. პარამეტრი no-clobber გამოტოვებულია\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "შეცდომა %d: %s.\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "ფაილის ზომა: %s (%jd ბაიტი)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "ფაილის ზომა: მიუწვდომელია"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "გამოტანის ფაილის (%s) გახსნა"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "სერვერი მხარდაჭერილი არაა. ვიწყებ ნულიდან, ერთი მიერთებით."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: შეცდომა. მდგომარეობის ფაილი არასრულია\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "მდგომარეობის ფაილში დამახსოვრებული მიერთებების რაოდენობა ბუნდოვანია\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "მდგომარეობის ფაილის ძველი ფორმატი.\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr ""
 "აღმოჩენილია მდგომარეობის ფაილი: %jd ბაიტი გადმოწერილია, %jd კი დარჩენილი."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "შეცდომა ლოკალური ფაილის გახსნისას"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "საზიზღარი ფაილური სისტემა/ოს-ი. ვეცდები, რამე ვქნა. :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "ლოკალური ფაილის გახსნის შეცდომა"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -95,59 +95,59 @@ msgstr ""
 "\n"
 "კავშირის თავიდან აქტივაცია: %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "გადმოწერის დასაწყისი"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "მიერთება %i ვიწერ %s:%i-დან %s ინტერფეისის გამოყენებით"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread-ის შეცდომა!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "შეცდომა კავშირის მოლოდინისას: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "%i: შეერთების მოლოდინის ვადა ამოიწურა"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "შეცდომა მიერთებაზე %i! კავშირი დახურულია"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "მიერთება %i მოულოდნელად დაიხურა"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "მიერთება %i დასრულდა"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "ჩაწერის შეცდომა!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "შეცდომა ნაძალადევი შეზღუდვისას: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "ძალიან ცოტაღა დარჩა. ერთ მიერთებას ვიტოვებ\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "ვიწერ: %jd-%jd მიერთებებით %i\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -19,139 +19,139 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8-bit\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Buffer verkleind voor deze snelheid."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "Kan URL niet verwerken.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr ""
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr ""
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr ""
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Bestandsgrootte: %s (%jd bytes)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "Bestandsgrootte: niet beschikbaar"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Openen uitvoerbestand %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Server niet ondersteund, opnieuw beginnen met 1 verbinding."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr ""
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr ""
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr ""
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Statusbestand gevonden: %jd bytes gedownload, %jd te gaan."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Fout bij openen lokaal bestand"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Niet-fatale fout in OS/bestandssysteem, omheen werken.."
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Fout bij maken lokaal bestand"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
 "Reactivate connection %d\n"
 msgstr ""
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Begin download"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Verbinding %i gebruikt server %s:%i via interface %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread fout!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Fout bij wachten op verbinding: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Time-out op verbinding %i"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Fout op verbinding %i! Verbinding gesloten"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Verbinding %i onverwachts gesloten"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Verbinding %i klaar"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Schrijffout!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr ""
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr ""
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -22,80 +22,80 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Buffer redimensionado para esta velocidade."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "Não posso analisar esta URL.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "Arquivo '%s' já existe; ignorando novo download do mesmo.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "Encontrado um download incompleto, ignorando opção no-clobber\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "ERRO %d: %s.\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Tamanho do arquivo: %s (%jd bytes)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "Tamanho do arquivo: indisponível"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Abrindo o arquivo de saída %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Servidor não suportado. Iniciando do zero com apenas uma conexão."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Erro, estado do arquivo alterado\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Número incorrecto de conexões armazenado no arquivo de estado\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Estado do arquivo foi alterado.\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Arquivo de estado encontrado: %jd bytes baixados, %jd restantes."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Erro ao abrir o arquivo local"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Filesystem/SO ruim... Trabalhando em torno disso. :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Erro ao criar o arquivo local"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -104,59 +104,59 @@ msgstr ""
 "\n"
 "Reativar conexão %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Iniciando o download"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Conexão %i baixando a partir de %s:%i, usando interface %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "erro de pthread!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Erro ao esperar por conexão: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Tempo esgotado para a conexão %i"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Erro na conexão %i! Conexão fechada."
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Conexão %i fechada inesperadamente"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Conexão %i finalizada"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Erro de escrita!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Erro ao aplicar regulagem de velocidade: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "Muito poucos bytes restantes, forçando uma única conexão\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, fuzzy, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "Baixando %jd-%jd usando conexão %i\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -11,83 +11,83 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Размер буфера изменен для этой скорости."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "Невозможно обработать URL.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "Файл '% s' уже существует; не получить.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "Обнаружена неполная загрузка, игнорируется опция no-clobber\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr ""
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, fuzzy, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Размер файла: %s (%jd байтасов)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 #, fuzzy
 msgid "File size: unavailable"
 msgstr "Размер файла: недоступен"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "Открывается выходной файл %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Сервер не поддерживается, начинаем заново с одним соединением."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Ошибка, усеченный файл состояния\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Поддельное количество соединений хранится в файле состояния\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Государственный файл имеет старый формат\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, fuzzy, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Найден файл состояния: %jd байта(ов) скачано, %jd осталось."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Ошибка при открытии локального файла"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr ""
 "Ошибки в файловой системе или операционной системе.. Пробуем исправить :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 #, fuzzy
 msgid "Error creating local file"
 msgstr "Ошибка при открытии локального файла"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -96,59 +96,59 @@ msgstr ""
 "\n"
 "Реактивировать соединение %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "Начинаем скачивание"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "Соединение %i скачивает с %s:%i через интерфейс %s"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "ошибка pthread!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, fuzzy, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Ошибка записи команды %s\n"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "Время соединения %i вышло"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "Ошибка в соединении %i! Соединение закрыто"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "Соединение %i неожиданно закрылось"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "Соединение %i закончилось"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Ошибка записи!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Ошибка при применении регулирования: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "Осталось слишком мало байтов, форсируя одно соединение\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, fuzzy, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "Загрузка %jd-%jd с использованием соединения %i\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -15,82 +15,82 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "Ara bellek bu hız için yeniden boyutlandırıldı."
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "URL çözümlenemedi.\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "'%s' adlı dosya halihazırda bulunuyor; erişim reddedildi.\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr ""
 "Tamamlanmamış indirme bulundu, no-clobber (çakışma önleyici) görmezeden "
 "geliniyor\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr ""
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "Dosya boyutu: %s (%jd bayt)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "Dosya boyutu: müsait değil"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "%s çıktı dosyası oluşturuluyor"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "Sunucu desteklenmiyor, tek bağlantı ile baştan başlanıyor."
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: Hata, eksikli durum dosyası\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "Durum dosyasında sahte sayıda bağlantı bulunuyor\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "Durum dosyası eski biçeme sahip.\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "Durum dosyası bulundu: %jd bayt indirildi, %jd kaldı."
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "Yerel dosyayı açarken hata"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "Dosya sistemi veya İS berbat durumda.. Bir şeyler deneniyor. :-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "Yerel dosya oluşturulurken hata"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -99,59 +99,59 @@ msgstr ""
 "\n"
 "%d bağlantısını tekrar çalıştır\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "İndirme başlatılıyor"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "%i bağlantısı %s:%i konumundan %s arayüzü kullanılarak indiriliyor"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread hatası!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "Bağlantı beklenirken hata: %s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "%i bağlantısı zaman aşımına uğradı"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "%i bağlantısında hata! Bağlantı kapatıldı."
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "%i bağlantısı beklenmedik bir şekilde kapatıldı"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "%i bağlantısı tamamlandı"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "Yazma hatası!"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "Kısmaya zorlanırken hata: %s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "Geriye çok az bayt kaldığı için tekli bağlantıya zorlanıyor\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, fuzzy, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "%jd-%jd conn kullanılarak indiriliyor. %i\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16,80 +16,80 @@ msgstr ""
 "Last-Revision: Li Jin <punkid.online@gmail.com>\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "为这个速率调整缓冲区大小。"
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "无法解析 URL。\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "文件 '%s' 已存在\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "发现不完整的下载，忽略 no-clobber 选项\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr ""
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, fuzzy, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "文件大小：%s (%jd 字节)"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "文件大小：不可用"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "正在打开输出文件 %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "服务器不支持，使用单个连接从头下载。"
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st: 错误，已清空的状态文件\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "状态文件中存储的连接数有误\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "状态文件版本陈旧\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, fuzzy, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "找到状态文件：已下载 %jd 字节，剩余 %jd 字节。"
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "无法打开本地文件"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "文件系统/操作系统不讨喜…… 正在寻求解决方法。:-("
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "无法创建本地文件"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -98,59 +98,59 @@ msgstr ""
 "\n"
 "重新激活连接 %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "正在开始下载"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "连接 %1$i 正通过接口 %4$s 从 %2$s:%3$i 下载"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread 出错啦！！！"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "等待连接 %s 时出错"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "连接 %i 超时"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "连接 %i 出错！连接中断"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "连接 %i 被异常中断"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "连接 %i 完成下载"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "写入错误！"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "强制调整流量时出错：%s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "剩余字节数过小，强制单连接下载\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, fuzzy, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "使用连接下载 %jd-%jd [%i]\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -13,80 +13,80 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/axel.c:150
+#: src/axel.c:146
 msgid "Buffer resized for this speed."
 msgstr "已調整緩衝區大小以配合此速度。"
 
-#: src/axel.c:179
+#: src/axel.c:178
 msgid "Could not parse URL.\n"
 msgstr "無法解析 URL。\n"
 
-#: src/axel.c:201
+#: src/axel.c:202
 #, c-format
 msgid "File '%s' already there; not retrieving.\n"
 msgstr "檔案 '%s' 已存在，將略過下載\n"
 
-#: src/axel.c:206
+#: src/axel.c:207
 #, c-format
 msgid "Incomplete download found, ignoring no-clobber option\n"
 msgstr "找到未完成的下載，忽略 no-clobber 選項\n"
 
-#: src/axel.c:223
+#: src/axel.c:227
 #, c-format
 msgid "ERROR %d: %s.\n"
 msgstr "錯誤 %d：%s。\n"
 
-#: src/axel.c:237
+#: src/axel.c:243
 #, c-format
 msgid "File size: %s (%jd bytes)"
 msgstr "檔案大小：%s（%jd 位元組）"
 
-#: src/axel.c:240
+#: src/axel.c:248
 msgid "File size: unavailable"
 msgstr "檔案大小：無法取得"
 
-#: src/axel.c:269
+#: src/axel.c:277
 #, c-format
 msgid "Opening output file %s"
 msgstr "開啟輸出檔案 %s"
 
-#: src/axel.c:276
+#: src/axel.c:285
 msgid "Server unsupported, starting from scratch with one connection."
 msgstr "伺服器不支援，從頭開始並使用單一連線。"
 
-#: src/axel.c:293
+#: src/axel.c:305
 #, c-format
 msgid "%s.st: Error, truncated state file\n"
 msgstr "%s.st：錯誤，狀態檔案被截斷\n"
 
-#: src/axel.c:301
+#: src/axel.c:314
 #, c-format
 msgid "Bogus number of connections stored in state file\n"
 msgstr "狀態檔案中儲存的連線數量不正確\n"
 
-#: src/axel.c:313
+#: src/axel.c:327
 #, c-format
 msgid "State file has old format.\n"
 msgstr "狀態檔案的格式較舊。\n"
 
-#: src/axel.c:346
+#: src/axel.c:363
 #, c-format
 msgid "State file found: %jd bytes downloaded, %jd to go."
 msgstr "找到狀態檔案：%jd 位元組已下載，還剩 %jd 位元組。"
 
-#: src/axel.c:352 src/axel.c:363
+#: src/axel.c:370 src/axel.c:383
 msgid "Error opening local file"
 msgstr "開啟本機檔案時出錯"
 
-#: src/axel.c:376
+#: src/axel.c:397
 msgid "Crappy filesystem/OS.. Working around. :-("
 msgstr "檔案系統/作業系統有問題.. 正在解決。:-( "
 
-#: src/axel.c:389
+#: src/axel.c:412
 msgid "Error creating local file"
 msgstr "建立本機檔案時出錯"
 
-#: src/axel.c:430
+#: src/axel.c:454
 #, c-format
 msgid ""
 "\n"
@@ -95,59 +95,59 @@ msgstr ""
 "\n"
 "重新啟動連線 %d\n"
 
-#: src/axel.c:459
+#: src/axel.c:482
 msgid "Starting download"
 msgstr "開始下載"
 
-#: src/axel.c:469 src/axel.c:652
+#: src/axel.c:497 src/axel.c:707
 #, c-format
 msgid "Connection %i downloading from %s:%i using interface %s"
 msgstr "連線 %i 正在從 %s:%i 使用介面 %s 下載"
 
-#: src/axel.c:479 src/axel.c:664
+#: src/axel.c:508 src/axel.c:722
 msgid "pthread error!!!"
 msgstr "pthread 錯誤!!!"
 
-#: src/axel.c:525
+#: src/axel.c:560
 #, c-format
 msgid "Error while waiting for connection: %s"
 msgstr "等待連線時出錯：%s"
 
-#: src/axel.c:557
+#: src/axel.c:596
 #, c-format
 msgid "Connection %i timed out"
 msgstr "連線 %i 逾時"
 
-#: src/axel.c:570
+#: src/axel.c:611
 #, c-format
 msgid "Error on connection %i! Connection closed"
 msgstr "連線 %i 出錯！連線已關閉"
 
-#: src/axel.c:584
+#: src/axel.c:629
 #, c-format
 msgid "Connection %i unexpectedly closed"
 msgstr "連線 %i 突然關閉"
 
-#: src/axel.c:588 src/axel.c:604
+#: src/axel.c:635 src/axel.c:654
 #, c-format
 msgid "Connection %i finished"
 msgstr "連線 %i 完成"
 
-#: src/axel.c:614
+#: src/axel.c:665
 msgid "Write error!"
 msgstr "寫入錯誤！"
 
-#: src/axel.c:716
+#: src/axel.c:791
 #, c-format
 msgid "Error while enforcing throttling: %s"
 msgstr "執行限速時出錯：%s"
 
-#: src/axel.c:901
+#: src/axel.c:986
 #, c-format
 msgid "Too few bytes remaining, forcing a single connection\n"
 msgstr "剩餘位元組太少，強制使用單一連線\n"
 
-#: src/axel.c:920
+#: src/axel.c:1007
 #, c-format
 msgid "Downloading %jd-%jd using conn. %i\n"
 msgstr "下載 %jd-%jd 正在使用連線 %i\n"
@@ -251,8 +251,7 @@ msgstr "寫入時連線已斷。\n"
 msgid ""
 "Too many custom headers (-H)! Currently only %u custom headers can be "
 "appended.\n"
-msgstr ""
-"自訂標頭（-H）過多！目前只能附加 %u 個自訂標頭。\n"
+msgstr "自訂標頭（-H）過多！目前只能附加 %u 個自訂標頭。\n"
 
 #: src/text.c:227
 #, c-format

--- a/src/axel.c
+++ b/src/axel.c
@@ -60,22 +60,22 @@ static void *setup_thread(void *);
 #ifdef __GNUC__
 __attribute__((format(printf, 2, 3)))
 #endif /* __GNUC__ */
-static void axel_message(axel_t *axel, const char *format, ...);
+static void
+axel_message(axel_t *axel, const char *format, ...);
 static void axel_divide(axel_t *axel);
 
 static char *buffer = NULL;
 
 #define MIN_CHUNK_WORTH (100 * 1024) /* 100 KB */
 
-
-static
-char *
+static char *
 stfile_makename(const char *bname)
 {
 	const char suffix[] = ".st";
 	const size_t bname_len = strlen(bname);
 	char *buf = malloc(bname_len + sizeof(suffix));
-	if (!buf) {
+	if (!buf)
+	{
 		perror("stfile_open");
 		abort();
 	}
@@ -84,9 +84,7 @@ stfile_makename(const char *bname)
 	return buf;
 }
 
-
-static
-int
+static int
 stfile_unlink(const char *bname)
 {
 	char *stname = stfile_makename(bname);
@@ -95,8 +93,7 @@ stfile_unlink(const char *bname)
 	return ret;
 }
 
-static
-int
+static int
 stfile_access(const char *bname, int mode)
 {
 	char *stname = stfile_makename(bname);
@@ -105,9 +102,7 @@ stfile_access(const char *bname, int mode)
 	return ret;
 }
 
-
-static
-int
+static int
 stfile_open(const char *bname, int flags, mode_t mode)
 {
 	char *stname = stfile_makename(bname);
@@ -115,7 +110,6 @@ stfile_open(const char *bname, int flags, mode_t mode)
 	free(stname);
 	return fd;
 }
-
 
 /* Create a new axel_t structure */
 axel_t *
@@ -142,22 +136,25 @@ axel_new(conf_t *conf, int count, const search_t *res)
 	for (i = 0; i < axel->conf->num_connections; i++)
 		pthread_mutex_init(&axel->conn[i].lock, NULL);
 
-	if (axel->conf->max_speed > 0) {
+	if (axel->conf->max_speed > 0)
+	{
 		/* max_speed / buffer_size < .5 */
-		if (16 * axel->conf->max_speed / axel->conf->buffer_size < 8) {
+		if (16 * axel->conf->max_speed / axel->conf->buffer_size < 8)
+		{
 			if (axel->conf->verbose >= 2)
 				axel_message(axel,
-					     _("Buffer resized for this speed."));
+							 _("Buffer resized for this speed."));
 			axel->conf->buffer_size = axel->conf->max_speed;
 		}
 		uint64_t delay =
 			UINT64_C(1073741824) * axel->conf->buffer_size *
 			axel->conf->num_connections / axel->conf->max_speed;
 
-		axel->delay_time.tv_sec  = delay / 1073741824;
+		axel->delay_time.tv_sec = delay / 1073741824;
 		axel->delay_time.tv_nsec = delay % 1073741824;
 	}
-	if (buffer == NULL) {
+	if (buffer == NULL)
+	{
 		buffer = malloc(axel->conf->buffer_size);
 		if (!buffer)
 			goto nomem;
@@ -168,14 +165,16 @@ axel_new(conf_t *conf, int count, const search_t *res)
 		goto nomem;
 	axel->url = u;
 
-	for (i = 0; i < count; i++) {
+	for (i = 0; i < count; i++)
+	{
 		strlcpy(u[i].text, res[i].url, sizeof(u[i].text));
 		u[i].next = &u[i + 1];
 	}
 	u[count - 1].next = u;
 
 	axel->conn[0].conf = axel->conf;
-	if (!conn_set(&axel->conn[0], axel->url->text)) {
+	if (!conn_set(&axel->conn[0], axel->url->text))
+	{
 		axel_message(axel, _("Could not parse URL.\n"));
 		axel->ready = -1;
 		return axel;
@@ -188,27 +187,31 @@ axel_new(conf_t *conf, int count, const search_t *res)
 	http_decode(axel->filename);
 
 	if ((s = strchr(axel->filename, '?')) != NULL &&
-	    axel->conf->strip_cgi_parameters)
-		*s = 0;		/* Get rid of CGI parameters */
+		axel->conf->strip_cgi_parameters)
+		*s = 0; /* Get rid of CGI parameters */
 
-	if (*axel->filename == 0)	/* Index page == no fn */
+	if (*axel->filename == 0) /* Index page == no fn */
 		strlcpy(axel->filename, axel->conf->default_filename,
-			sizeof(axel->filename));
+				sizeof(axel->filename));
 
-	if (axel->conf->no_clobber && access(axel->filename, F_OK) == 0) {
+	if (axel->conf->no_clobber && access(axel->filename, F_OK) == 0)
+	{
 		int ret = stfile_access(axel->filename, F_OK);
-		if (ret) {
+		if (ret)
+		{
 			printf(_("File '%s' already there; not retrieving.\n"),
-			       axel->filename);
+				   axel->filename);
 			axel->ready = -1;
 			return axel;
 		}
 		printf(_("Incomplete download found, ignoring "
-			 "no-clobber option\n"));
+				 "no-clobber option\n"));
 	}
 
-	do {
-		if (!conn_init(&axel->conn[0])) {
+	do
+	{
+		if (!conn_init(&axel->conn[0]))
+		{
 			axel_message(axel, "%s", axel->conn[0].message);
 			axel->ready = -1;
 			return axel;
@@ -217,7 +220,8 @@ axel_new(conf_t *conf, int count, const search_t *res)
 		/* This does more than just checking the file size, it all
 		 * depends on the protocol used. */
 		status = conn_info(&axel->conn[0]);
-		if (!status) {
+		if (!status)
+		{
 			char msg[80];
 			int code = conn_info_status_get(msg, sizeof(msg), axel->conn);
 			fprintf(stderr, _("ERROR %d: %s.\n"), code, msg);
@@ -225,18 +229,22 @@ axel_new(conf_t *conf, int count, const search_t *res)
 			return axel;
 		}
 	} while (status == -1); /* re-init in case of protocol change. This can
-				 * happen only once because the FTP protocol
-				 * can't redirect back to HTTP */
+							 * happen only once because the FTP protocol
+							 * can't redirect back to HTTP */
 
 	conn_url(axel->url->text, sizeof(axel->url->text) - 1, axel->conn);
 	axel->size = axel->conn[0].size;
-	if (axel->conf->verbose > 0) {
-		if (axel->size != LLONG_MAX) {
+	if (axel->conf->verbose > 0)
+	{
+		if (axel->size != LLONG_MAX)
+		{
 			char hsize[32];
 			axel_size_human(hsize, sizeof(hsize), axel->size);
 			axel_message(axel, _("File size: %s (%jd bytes)"),
-				     hsize, axel->size);
-		} else {
+						 hsize, axel->size);
+		}
+		else
+		{
 			axel_message(axel, _("File size: unavailable"));
 		}
 	}
@@ -244,23 +252,23 @@ axel_new(conf_t *conf, int count, const search_t *res)
 	/* Wildcards in URL --> Get complete filename */
 	if (axel->filename[strcspn(axel->filename, "*?")])
 		strlcpy(axel->filename, axel->conn[0].file,
-			sizeof(axel->filename));
+				sizeof(axel->filename));
 
-	if (*axel->conn[0].output_filename != 0) {
+	if (*axel->conn[0].output_filename != 0)
+	{
 		strlcpy(axel->filename, axel->conn[0].output_filename,
-			sizeof(axel->filename));
+				sizeof(axel->filename));
 	}
 
 	return axel;
- nomem:
+nomem:
 	axel_close(axel);
 	printf("%s\n", strerror(errno));
 	return NULL;
 }
 
 /* Open a local file to store the downloaded data */
-int
-axel_open(axel_t *axel)
+int axel_open(axel_t *axel)
 {
 	int i, fd;
 	ssize_t nread;
@@ -272,9 +280,10 @@ axel_open(axel_t *axel)
 
 	/* Check whether server knows about RESTart and switch back to
 	   single connection download if necessary */
-	if (!axel->conn[0].supported) {
+	if (!axel->conn[0].supported)
+	{
 		axel_message(axel, _("Server unsupported, "
-				     "starting from scratch with one connection."));
+							 "starting from scratch with one connection."));
 		axel->conf->num_connections = 1;
 		void *new_conn = realloc(axel->conn, sizeof(conn_t));
 		if (!new_conn)
@@ -282,31 +291,36 @@ axel_open(axel_t *axel)
 
 		axel->conn = new_conn;
 		axel_divide(axel);
-	} else if ((fd = stfile_open(axel->filename, O_RDONLY, 0)) != -1) {
+	}
+	else if ((fd = stfile_open(axel->filename, O_RDONLY, 0)) != -1)
+	{
 		int old_format = 0;
 		off_t stsize = lseek(fd, 0, SEEK_END);
 		lseek(fd, 0, SEEK_SET);
 
 		nread = read(fd, &axel->conf->num_connections,
-			     sizeof(axel->conf->num_connections));
-		if (nread != sizeof(axel->conf->num_connections)) {
+					 sizeof(axel->conf->num_connections));
+		if (nread != sizeof(axel->conf->num_connections))
+		{
 			printf(_("%s.st: Error, truncated state file\n"),
-			       axel->filename);
+				   axel->filename);
 			close(fd);
 			return 0;
 		}
 
-		if (axel->conf->num_connections < 1) {
+		if (axel->conf->num_connections < 1)
+		{
 			fprintf(stderr,
-				_("Bogus number of connections stored in state file\n"));
+					_("Bogus number of connections stored in state file\n"));
 			close(fd);
 			return 0;
 		}
 
 		if (stsize < (off_t)(sizeof(axel->conf->num_connections) +
-				     sizeof(axel->bytes_done) +
-				     2 * axel->conf->num_connections *
-				     sizeof(axel->conn[0].currentbyte))) {
+							 sizeof(axel->bytes_done) +
+							 2 * axel->conf->num_connections *
+								 sizeof(axel->conn[0].currentbyte)))
+		{
 			/* FIXME this might be wrong, the file may have been
 			 * truncated, we need another way to check. */
 #ifndef NDEBUG
@@ -316,50 +330,56 @@ axel_open(axel_t *axel)
 		}
 
 		void *new_conn = realloc(axel->conn, sizeof(conn_t) *
-					 axel->conf->num_connections);
-		if (!new_conn) {
+												 axel->conf->num_connections);
+		if (!new_conn)
+		{
 			close(fd);
 			return 0;
 		}
 		axel->conn = new_conn;
 
 		memset(axel->conn + 1, 0,
-		       sizeof(conn_t) * (axel->conf->num_connections - 1));
+			   sizeof(conn_t) * (axel->conf->num_connections - 1));
 
 		if (old_format)
 			axel_divide(axel);
 
 		nread = read(fd, &axel->bytes_done, sizeof(axel->bytes_done));
 		assert(nread == sizeof(axel->bytes_done));
-		for (i = 0; i < axel->conf->num_connections; i++) {
+		for (i = 0; i < axel->conf->num_connections; i++)
+		{
 			nread = read(fd, &axel->conn[i].currentbyte,
-				     sizeof(axel->conn[i].currentbyte));
+						 sizeof(axel->conn[i].currentbyte));
 			assert(nread == sizeof(axel->conn[i].currentbyte));
-			if (!old_format) {
+			if (!old_format)
+			{
 				nread = read(fd, &axel->conn[i].lastbyte,
-					     sizeof(axel->conn[i].lastbyte));
+							 sizeof(axel->conn[i].lastbyte));
 				assert(nread == sizeof(axel->conn[i].lastbyte));
 			}
 		}
 
 		axel_message(axel,
-			     _("State file found: %jd bytes downloaded, %jd to go."),
-			     axel->bytes_done, axel->size - axel->bytes_done);
+					 _("State file found: %jd bytes downloaded, %jd to go."),
+					 axel->bytes_done, axel->size - axel->bytes_done);
 
 		close(fd);
 
-		if ((axel->outfd = open(axel->filename, O_WRONLY, 0666)) == -1) {
+		if ((axel->outfd = open(axel->filename, O_WRONLY, 0666)) == -1)
+		{
 			axel_message(axel, _("Error opening local file"));
 			return 0;
 		}
 	}
 
 	/* If outfd == -1 we have to start from scrath now */
-	if (axel->outfd == -1) {
+	if (axel->outfd == -1)
+	{
 		axel_divide(axel);
 
 		if ((axel->outfd =
-		     open(axel->filename, O_CREAT | O_WRONLY, 0666)) == -1) {
+				 open(axel->filename, O_CREAT | O_WRONLY, 0666)) == -1)
+		{
 			axel_message(axel, _("Error opening local file"));
 			return 0;
 		}
@@ -368,25 +388,28 @@ axel_open(axel_t *axel)
 		   past-EOF areas.. Speeds things up. :) AFAIK this
 		   should just not happen: */
 		if (lseek(axel->outfd, axel->size, SEEK_SET) == -1 &&
-		    axel->conf->num_connections > 1) {
+			axel->conf->num_connections > 1)
+		{
 			/* But if the OS/fs does not allow to seek behind
 			   EOF, we have to fill the file with zeroes before
 			   starting. Slow.. */
 			axel_message(axel,
-				     _("Crappy filesystem/OS.. Working around. :-("));
+						 _("Crappy filesystem/OS.. Working around. :-("));
 			lseek(axel->outfd, 0, SEEK_SET);
 			memset(buffer, 0, axel->conf->buffer_size);
 			off_t j = axel->size;
-			while (j > 0) {
+			while (j > 0)
+			{
 				ssize_t nwrite;
 
 				if ((nwrite =
-				     write(axel->outfd, buffer,
-					   min(j, axel->conf->buffer_size))) < 0) {
+						 write(axel->outfd, buffer,
+							   min(j, axel->conf->buffer_size))) < 0)
+				{
 					if (errno == EINTR || errno == EAGAIN)
 						continue;
 					axel_message(axel,
-						     _("Error creating local file"));
+								 _("Error creating local file"));
 					return 0;
 				}
 				j -= nwrite;
@@ -403,8 +426,7 @@ axel_open(axel_t *axel)
  *
  * Must be called with the conn_t lock held.
  */
-static
-void
+static void
 reactivate_connection(axel_t *axel, int thread)
 {
 	/* TODO Make the minimum also depend on the connection speed */
@@ -412,13 +434,15 @@ reactivate_connection(axel_t *axel, int thread)
 	int idx = -1;
 
 	if (axel->conn[thread].enabled ||
-	    axel->conn[thread].currentbyte < axel->conn[thread].lastbyte)
+		axel->conn[thread].currentbyte < axel->conn[thread].lastbyte)
 		return;
 
-	for (int j = 0; j < axel->conf->num_connections; j++) {
+	for (int j = 0; j < axel->conf->num_connections; j++)
+	{
 		off_t remaining =
 			axel->conn[j].lastbyte - axel->conn[j].currentbyte;
-		if (remaining > max_remaining) {
+		if (remaining > max_remaining)
+		{
 			max_remaining = remaining;
 			idx = j;
 		}
@@ -430,14 +454,12 @@ reactivate_connection(axel_t *axel, int thread)
 	printf(_("\nReactivate connection %d\n"), thread);
 #endif
 	axel->conn[thread].lastbyte = axel->conn[idx].lastbyte;
-	axel->conn[idx].lastbyte = axel->conn[idx].currentbyte
-		+ max_remaining / 2;
+	axel->conn[idx].lastbyte = axel->conn[idx].currentbyte + max_remaining / 2;
 	axel->conn[thread].currentbyte = axel->conn[idx].lastbyte;
 }
 
 /* Start downloading */
-void
-axel_start(axel_t *axel)
+void axel_start(axel_t *axel)
 {
 	int i;
 	url_t *url_ptr;
@@ -445,7 +467,8 @@ axel_start(axel_t *axel)
 	/* HTTP might've redirected and FTP handles wildcards, so
 	   re-scan the URL for every conn */
 	url_ptr = axel->url;
-	for (i = 0; i < axel->conf->num_connections; i++) {
+	for (i = 0; i < axel->conf->num_connections; i++)
+	{
 		conn_set(&axel->conn[i], url_ptr->text);
 		url_ptr = url_ptr->next;
 		axel->conn[i].local_if = axel->conf->interfaces->text;
@@ -458,25 +481,32 @@ axel_start(axel_t *axel)
 	if (axel->conf->verbose > 0)
 		axel_message(axel, _("Starting download"));
 
-	for (i = 0; i < axel->conf->num_connections; i++) {
-		if (axel->conn[i].currentbyte >= axel->conn[i].lastbyte) {
+	for (i = 0; i < axel->conf->num_connections; i++)
+	{
+		if (axel->conn[i].currentbyte >= axel->conn[i].lastbyte)
+		{
 			pthread_mutex_lock(&axel->conn[i].lock);
 			reactivate_connection(axel, i);
 			pthread_mutex_unlock(&axel->conn[i].lock);
-		} else if (axel->conn[i].currentbyte < axel->conn[i].lastbyte) {
-			if (axel->conf->verbose >= 2) {
+		}
+		else if (axel->conn[i].currentbyte < axel->conn[i].lastbyte)
+		{
+			if (axel->conf->verbose >= 2)
+			{
 				axel_message(axel,
-					     _("Connection %i downloading from %s:%i using interface %s"),
-					     i, axel->conn[i].host,
-					     axel->conn[i].port,
-					     axel->conn[i].local_if);
+							 _("Connection %i downloading from %s:%i using interface %s"),
+							 i, axel->conn[i].host,
+							 axel->conn[i].port,
+							 axel->conn[i].local_if);
 			}
 
 			axel->conn[i].state = true;
-			if (pthread_create
-			    (axel->conn[i].setup_thread, NULL, setup_thread,
-			     &axel->conn[i]) != 0) {
+
+			if (pthread_create(axel->conn[i].setup_thread, NULL, setup_thread,
+							   &axel->conn[i]) != 0)
+			{
 				axel_message(axel, _("pthread error!!!"));
+
 				axel->ready = -1;
 			}
 		}
@@ -488,8 +518,7 @@ axel_start(axel_t *axel)
 }
 
 /* Main 'loop' */
-void
-axel_do(axel_t *axel)
+void axel_do(axel_t *axel)
 {
 	fd_set fds[1];
 	int hifd, i;
@@ -500,7 +529,8 @@ axel_do(axel_t *axel)
 	unsigned long long int max_speed_ratio;
 
 	/* Create statefile if necessary */
-	if (axel_gettime() > axel->next_state) {
+	if (axel_gettime() > axel->next_state)
+	{
 		save_state(axel);
 		axel->next_state = axel_gettime() + axel->conf->save_state_interval;
 	}
@@ -508,22 +538,27 @@ axel_do(axel_t *axel)
 	/* Wait for data on (one of) the connections */
 	FD_ZERO(fds);
 	hifd = 0;
-	for (i = 0; i < axel->conf->num_connections; i++) {
+	for (i = 0; i < axel->conf->num_connections; i++)
+	{
 		/* skip connection if setup thread hasn't released the lock yet */
-		if (!pthread_mutex_trylock(&axel->conn[i].lock)) {
-			if (axel->conn[i].enabled) {
+		if (!pthread_mutex_trylock(&axel->conn[i].lock))
+		{
+			if (axel->conn[i].enabled)
+			{
 				FD_SET(axel->conn[i].tcp->fd, fds);
 				hifd = max(hifd, axel->conn[i].tcp->fd);
 			}
 			pthread_mutex_unlock(&axel->conn[i].lock);
 		}
 	}
-	if (hifd == 0) {
+	if (hifd == 0)
+	{
 		/* No connections yet. Wait... */
-		if (axel_sleep(delay) < 0) {
+		if (axel_sleep(delay) < 0)
+		{
 			axel_message(axel,
-				     _("Error while waiting for connection: %s"),
-				     strerror(errno));
+						 _("Error while waiting for connection: %s"),
+						 strerror(errno));
 			axel->ready = -1;
 			return;
 		}
@@ -532,7 +567,8 @@ axel_do(axel_t *axel)
 
 	timeval->tv_sec = 0;
 	timeval->tv_usec = 100000;
-	if (select(hifd + 1, fds, NULL, NULL, timeval) == -1) {
+	if (select(hifd + 1, fds, NULL, NULL, timeval) == -1)
+	{
 		/* A select() error probably means it was interrupted
 		 * by a signal, or that something else's very wrong... */
 		axel->ready = -1;
@@ -540,7 +576,8 @@ axel_do(axel_t *axel)
 	}
 
 	/* Handle connections which need attention */
-	for (i = 0; i < axel->conf->num_connections; i++) {
+	for (i = 0; i < axel->conf->num_connections; i++)
+	{
 		/* skip connection if setup thread hasn't released the lock yet */
 		if (pthread_mutex_trylock(&axel->conn[i].lock))
 			continue;
@@ -548,14 +585,16 @@ axel_do(axel_t *axel)
 		if (!axel->conn[i].enabled)
 			goto next_conn;
 
-		if (!FD_ISSET(axel->conn[i].tcp->fd, fds)) {
+		if (!FD_ISSET(axel->conn[i].tcp->fd, fds))
+		{
 			time_t timeout = axel->conn[i].last_transfer +
-			    axel->conf->connection_timeout;
-			if (axel_gettime() > timeout) {
+							 axel->conf->connection_timeout;
+			if (axel_gettime() > timeout)
+			{
 				if (axel->conf->verbose)
 					axel_message(axel,
-						     _("Connection %i timed out"),
-						     i);
+								 _("Connection %i timed out"),
+								 i);
 				conn_disconnect(&axel->conn[i]);
 			}
 			goto next_conn;
@@ -563,33 +602,42 @@ axel_do(axel_t *axel)
 
 		axel->conn[i].last_transfer = axel_gettime();
 		size =
-		    tcp_read(axel->conn[i].tcp, buffer,
-			     axel->conf->buffer_size);
-		if (size == -1) {
-			if (axel->conf->verbose) {
+			tcp_read(axel->conn[i].tcp, buffer,
+					 axel->conf->buffer_size);
+		if (size == -1)
+		{
+			if (axel->conf->verbose)
+			{
 				axel_message(axel, _("Error on connection %i! "
-						     "Connection closed"), i);
+									 "Connection closed"),
+							 i);
 			}
 			conn_disconnect(&axel->conn[i]);
 			goto next_conn;
 		}
 
-		if (size == 0) {
-			if (axel->conf->verbose) {
+		if (size == 0)
+		{
+			if (axel->conf->verbose)
+			{
 				/* Only abnormal behaviour if: */
 				if (axel->conn[i].currentbyte <
-				    axel->conn[i].lastbyte &&
-				    axel->size != LLONG_MAX) {
+						axel->conn[i].lastbyte &&
+					axel->size != LLONG_MAX)
+				{
 					axel_message(axel,
-						     _("Connection %i unexpectedly closed"),
-						     i);
-				} else {
+								 _("Connection %i unexpectedly closed"),
+								 i);
+				}
+				else
+				{
 					axel_message(axel,
-						     _("Connection %i finished"),
-						     i);
+								 _("Connection %i finished"),
+								 i);
 				}
 			}
-			if (!axel->conn[0].supported) {
+			if (!axel->conn[0].supported)
+			{
 				axel->ready = 1;
 			}
 			conn_disconnect(&axel->conn[i]);
@@ -599,10 +647,12 @@ axel_do(axel_t *axel)
 
 		/* remaining == Bytes to go */
 		remaining = axel->conn[i].lastbyte - axel->conn[i].currentbyte;
-		if (remaining < size) {
-			if (axel->conf->verbose) {
+		if (remaining < size)
+		{
+			if (axel->conf->verbose)
+			{
 				axel_message(axel, _("Connection %i finished"),
-					     i);
+							 i);
 			}
 			conn_disconnect(&axel->conn[i]);
 			size = remaining;
@@ -610,7 +660,8 @@ axel_do(axel_t *axel)
 		}
 		/* This should always succeed.. */
 		lseek(axel->outfd, axel->conn[i].currentbyte, SEEK_SET);
-		if (write(axel->outfd, buffer, size) != size) {
+		if (write(axel->outfd, buffer, size) != size)
+		{
 			axel_message(axel, _("Write error!"));
 			axel->ready = -1;
 			pthread_mutex_unlock(&axel->conn[i].lock);
@@ -621,27 +672,31 @@ axel_do(axel_t *axel)
 		if (remaining == size)
 			reactivate_connection(axel, i);
 
- next_conn:
+	next_conn:
 		pthread_mutex_unlock(&axel->conn[i].lock);
 	}
 
 	if (axel->ready)
 		return;
 
- conn_check:
+conn_check:
 	/* Look for aborted connections and attempt to restart them. */
 	url_ptr = axel->url;
-	for (i = 0; i < axel->conf->num_connections; i++) {
+	for (i = 0; i < axel->conf->num_connections; i++)
+	{
 		/* skip connection if setup thread hasn't released the lock yet */
 		if (pthread_mutex_trylock(&axel->conn[i].lock))
 			continue;
 
 		if (!axel->conn[i].enabled &&
-		    axel->conn[i].currentbyte < axel->conn[i].lastbyte) {
-			if (!axel->conn[i].state) {
+			axel->conn[i].currentbyte < axel->conn[i].lastbyte)
+		{
+			if (!axel->conn[i].state && !axel->conn[i].joined)
+			{
 				// Wait for termination of this thread
 				pthread_join(*(axel->conn[i].setup_thread),
-					     NULL);
+							 NULL);
+				axel->conn[i].joined = true;
 
 				conn_set(&axel->conn[i], url_ptr->text);
 				url_ptr = url_ptr->next;
@@ -649,28 +704,37 @@ axel_do(axel_t *axel)
 				   axel->conf->interfaces = axel->conf->interfaces->next; */
 				if (axel->conf->verbose >= 2)
 					axel_message(axel,
-						     _("Connection %i downloading from %s:%i using interface %s"),
-						     i, axel->conn[i].host,
-						     axel->conn[i].port,
-						     axel->conn[i].local_if);
+								 _("Connection %i downloading from %s:%i using interface %s"),
+								 i, axel->conn[i].host,
+								 axel->conn[i].port,
+								 axel->conn[i].local_if);
 
 				axel->conn[i].state = true;
-				if (pthread_create
-				    (axel->conn[i].setup_thread, NULL,
-				     setup_thread, &axel->conn[i]) == 0) {
+				if (pthread_create(axel->conn[i].setup_thread, NULL,
+								   setup_thread, &axel->conn[i]) == 0)
+				{
 					axel->conn[i].last_transfer = axel_gettime();
-				} else {
+					axel->conn[i].joined = false;
+				}
+				else
+				{
 					axel_message(axel,
-						     _("pthread error!!!"));
+								 _("pthread error!!!"));
 					axel->ready = -1;
 				}
-			} else {
+			}
+			else
+			{
 				if (axel_gettime() > (axel->conn[i].last_transfer +
-						 axel->conf->reconnect_delay)) {
+									  axel->conf->reconnect_delay))
+				{
 					pthread_cancel(*axel->conn[i].setup_thread);
 					axel->conn[i].state = false;
-					pthread_join(*axel->conn[i].
-						     setup_thread, NULL);
+					if (!axel->conn[i].joined && !axel->conn[i].state)
+					{
+						pthread_join(*axel->conn[i].setup_thread, NULL);
+						axel->conn[i].joined = true;
+					}
 				}
 			}
 		}
@@ -679,42 +743,53 @@ axel_do(axel_t *axel)
 
 	/* Calculate current average speed and finish_time */
 	axel->bytes_per_second =
-	    (off_t)((double)(axel->bytes_done - axel->start_byte) /
-		  (axel_gettime() - axel->start_time));
+		(off_t)((double)(axel->bytes_done - axel->start_byte) /
+				(axel_gettime() - axel->start_time));
 	if (axel->bytes_per_second != 0)
 		axel->finish_time =
-		    (int)(axel->start_time +
-			  (double)(axel->size - axel->start_byte) /
-			  axel->bytes_per_second);
+			(int)(axel->start_time +
+				  (double)(axel->size - axel->start_byte) /
+					  axel->bytes_per_second);
 	else
 		axel->finish_time = INT_MAX;
 
 	/* Check speed. If too high, delay for some time to slow things
 	   down a bit. I think a 5% deviation should be acceptable. */
-	if (axel->conf->max_speed > 0) {
+	if (axel->conf->max_speed > 0)
+	{
 		max_speed_ratio = 1000 * axel->bytes_per_second /
-		    axel->conf->max_speed;
-		if (max_speed_ratio > 1050) {
+						  axel->conf->max_speed;
+		if (max_speed_ratio > 1050)
+		{
 			axel->delay_time.tv_nsec += 10000000;
-			if (axel->delay_time.tv_nsec >= 1000000000) {
+			if (axel->delay_time.tv_nsec >= 1000000000)
+			{
 				axel->delay_time.tv_sec++;
 				axel->delay_time.tv_nsec -= 1000000000;
 			}
-		} else if (max_speed_ratio < 950) {
-			if (axel->delay_time.tv_nsec >= 10000000) {
+		}
+		else if (max_speed_ratio < 950)
+		{
+			if (axel->delay_time.tv_nsec >= 10000000)
+			{
 				axel->delay_time.tv_nsec -= 10000000;
-			} else if (axel->delay_time.tv_sec > 0) {
+			}
+			else if (axel->delay_time.tv_sec > 0)
+			{
 				axel->delay_time.tv_sec--;
 				axel->delay_time.tv_nsec += 999000000;
-			} else {
+			}
+			else
+			{
 				axel->delay_time.tv_sec = 0;
 				axel->delay_time.tv_nsec = 0;
 			}
 		}
-		if (axel_sleep(axel->delay_time) < 0) {
+		if (axel_sleep(axel->delay_time) < 0)
+		{
 			axel_message(axel,
-				     _("Error while enforcing throttling: %s"),
-				     strerror(errno));
+						 _("Error while enforcing throttling: %s"),
+						 strerror(errno));
 			axel->ready = -1;
 			return;
 		}
@@ -726,8 +801,7 @@ axel_do(axel_t *axel)
 }
 
 /* Close an axel connection */
-void
-axel_close(axel_t *axel)
+void axel_close(axel_t *axel)
 {
 	if (!axel)
 		return;
@@ -736,11 +810,15 @@ axel_close(axel_t *axel)
 	assert(axel->conn);
 
 	/* Terminate threads and close connections */
-	for (int i = 0; i < axel->conf->num_connections; i++) {
+	for (int i = 0; i < axel->conf->num_connections; i++)
+	{
+		pthread_cancel(*axel->conn[i].setup_thread);
 		/* don't try to kill non existing thread */
-		if (*axel->conn[i].setup_thread != 0) {
-			pthread_cancel(*axel->conn[i].setup_thread);
+		if (*axel->conn[i].setup_thread != 0)
+		{
+
 			pthread_join(*axel->conn[i].setup_thread, NULL);
+			axel->conn[i].joined = true;
 		}
 		conn_disconnect(&axel->conn[i]);
 	}
@@ -748,11 +826,13 @@ axel_close(axel_t *axel)
 	free(axel->url);
 
 	/* Delete state file if necessary */
-	if (axel->ready == 1) {
+	if (axel->ready == 1)
+	{
 		stfile_unlink(axel->filename);
 	}
 	/* Else: Create it.. */
-	else if (axel->bytes_done > 0) {
+	else if (axel->bytes_done > 0)
+	{
 		save_state(axel);
 	}
 
@@ -760,7 +840,8 @@ axel_close(axel_t *axel)
 
 	close(axel->outfd);
 
-	if (!PROTO_IS_FTP(axel->conn->proto) || axel->conn->proxy) {
+	if (!PROTO_IS_FTP(axel->conn->proto) || axel->conn->proxy)
+	{
 		abuf_setup(axel->conn->http->request, ABUF_FREE);
 		abuf_setup(axel->conn->http->headers, ABUF_FREE);
 	}
@@ -782,8 +863,7 @@ axel_gettime(void)
 /**
  * Save the state of the current download.
  */
-static
-void
+static void
 save_state(axel_t *axel)
 {
 	/* No use for such a file if the server doesn't support
@@ -793,36 +873,37 @@ save_state(axel_t *axel)
 
 	int fd;
 	fd = stfile_open(axel->filename, O_CREAT | O_TRUNC | O_WRONLY, 0666);
-	if (fd == -1) {
-		return;		/* Not 100% fatal.. */
+	if (fd == -1)
+	{
+		return; /* Not 100% fatal.. */
 	}
 
 	ssize_t nwrite;
 	(void)nwrite; /* workaround unused variable warning */
 	nwrite =
-	    write(fd, &axel->conf->num_connections,
-		  sizeof(axel->conf->num_connections));
+		write(fd, &axel->conf->num_connections,
+			  sizeof(axel->conf->num_connections));
 	assert(nwrite == sizeof(axel->conf->num_connections));
 
 	nwrite = write(fd, &axel->bytes_done, sizeof(axel->bytes_done));
 	assert(nwrite == sizeof(axel->bytes_done));
 
-	for (int i = 0; i < axel->conf->num_connections; i++) {
+	for (int i = 0; i < axel->conf->num_connections; i++)
+	{
 		nwrite =
-		    write(fd, &axel->conn[i].currentbyte,
-			  sizeof(axel->conn[i].currentbyte));
+			write(fd, &axel->conn[i].currentbyte,
+				  sizeof(axel->conn[i].currentbyte));
 		assert(nwrite == sizeof(axel->conn[i].currentbyte));
 		nwrite =
-		    write(fd, &axel->conn[i].lastbyte,
-			  sizeof(axel->conn[i].lastbyte));
+			write(fd, &axel->conn[i].lastbyte,
+				  sizeof(axel->conn[i].lastbyte));
 		assert(nwrite == sizeof(axel->conn[i].lastbyte));
 	}
 	close(fd);
 }
 
 /* Thread used to set up a connection */
-static
-void *
+static void *
 setup_thread(void *c)
 {
 	conn_t *conn = c;
@@ -833,9 +914,11 @@ setup_thread(void *c)
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldstate);
 
 	pthread_mutex_lock(&conn->lock);
-	if (conn_setup(conn)) {
+	if (conn_setup(conn))
+	{
 		conn->last_transfer = axel_gettime();
-		if (conn_exec(conn)) {
+		if (conn_exec(conn))
+		{
 			conn->last_transfer = axel_gettime();
 			conn->enabled = true;
 			goto out;
@@ -843,7 +926,7 @@ setup_thread(void *c)
 	}
 
 	conn_disconnect(conn);
- out:
+out:
 	conn->state = false;
 	pthread_mutex_unlock(&conn->lock);
 
@@ -868,16 +951,19 @@ axel_message(axel_t *axel, const char *format, ...)
 	vsnprintf(m->text, MAX_STRING, format, params);
 	va_end(params);
 
-	if (axel->message == NULL) {
+	if (axel->message == NULL)
+	{
 		axel->message = axel->last_message = m;
-	} else {
+	}
+	else
+	{
 		axel->last_message->next = m;
 		axel->last_message = m;
 	}
 
 	return;
 
- nomem:
+nomem:
 	/* Flush previous messages */
 	print_messages(axel);
 	va_start(params, format);
@@ -897,7 +983,8 @@ axel_divide(axel_t *axel)
 	/* Calculate each segment's size */
 	off_t seg_len = axel->size / axel->conf->num_connections;
 
-	if (!seg_len) {
+	if (!seg_len)
+	{
 		printf(_("Too few bytes remaining, forcing a single connection\n"));
 		axel->conf->num_connections = 1;
 		seg_len = axel->size;
@@ -907,19 +994,21 @@ axel_divide(axel_t *axel)
 			axel->conn = new_conn;
 	}
 
-	for (int i = 0; i < axel->conf->num_connections; i++) {
+	for (int i = 0; i < axel->conf->num_connections; i++)
+	{
 		axel->conn[i].currentbyte = seg_len * i;
-		axel->conn[i].lastbyte    = seg_len * i + seg_len;
+		axel->conn[i].lastbyte = seg_len * i + seg_len;
 	}
 
 	/* Last connection downloads remaining bytes */
 	size_t tail = axel->size % seg_len;
 	axel->conn[axel->conf->num_connections - 1].lastbyte += tail;
 #ifndef NDEBUG
-	for (int i = 0; i < axel->conf->num_connections; i++) {
+	for (int i = 0; i < axel->conf->num_connections; i++)
+	{
 		printf(_("Downloading %jd-%jd using conn. %i\n"),
-		       axel->conn[i].currentbyte,
-		       axel->conn[i].lastbyte, i);
+			   axel->conn[i].currentbyte,
+			   axel->conn[i].lastbyte, i);
 	}
 #endif
 }


### PR DESCRIPTION
This PR fixes #411 by adding a joined flag to **conn_t** and using it to safely join setup threads only if needed. Code now avoids joining/already-joined or uninitialized threads.